### PR TITLE
修复聊天区“回到底部”按钮误显

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 修复聊天区在已滚动到底部时仍错误显示“回到底部”按钮的问题，统一基于实际离底距离判断按钮显隐。
+
 ## [0.0.1] - 2026-03-14
 
 ### Fixed

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -141,17 +141,8 @@ export function ChatInterface({
     }
   }, []);
 
-  const stopFollowingLatest = useCallback(() => {
+  const scheduleScrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     cancelPendingScroll();
-    shouldFollowLatestRef.current = false;
-    setShowScrollToBottom(true);
-  }, [cancelPendingScroll]);
-
-  // 滚动到底部的函数
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    cancelPendingScroll();
-    shouldFollowLatestRef.current = true;
-    setShowScrollToBottom(false);
 
     // 使用底部锚点滚动，避免 scrollHeight 在布局抖动时不准确。
     pendingScrollFrameRef.current = requestAnimationFrame(() => {
@@ -164,6 +155,13 @@ export function ChatInterface({
     });
   }, [cancelPendingScroll]);
 
+  // 滚动到底部的函数
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    shouldFollowLatestRef.current = true;
+    setShowScrollToBottom(false);
+    scheduleScrollToBottom(behavior);
+  }, [scheduleScrollToBottom]);
+
   // 消息变化时仅在“跟随最新输出”模式下自动滚动。
   useEffect(() => {
     if (!shouldFollowLatestRef.current) {
@@ -171,8 +169,8 @@ export function ChatInterface({
       return;
     }
 
-    scrollToBottom(isLoading ? 'auto' : 'smooth');
-  }, [isLoading, messages, scrollToBottom, updateFollowState]);
+    scheduleScrollToBottom(isLoading ? 'auto' : 'smooth');
+  }, [isLoading, messages, scheduleScrollToBottom, updateFollowState]);
 
   useEffect(() => {
     updateFollowState();
@@ -196,18 +194,17 @@ export function ChatInterface({
     lastScrollTopRef.current = currentScrollTop;
 
     if (isScrollingUp) {
-      stopFollowingLatest();
-      return;
+      cancelPendingScroll();
     }
 
     updateFollowState();
-  }, [stopFollowingLatest, updateFollowState]);
+  }, [cancelPendingScroll, updateFollowState]);
 
   const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
     if (event.deltaY < 0) {
-      stopFollowingLatest();
+      cancelPendingScroll();
     }
-  }, [stopFollowingLatest]);
+  }, [cancelPendingScroll]);
 
   const handleTouchStart = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
     touchStartYRef.current = event.touches[0]?.clientY ?? null;
@@ -219,9 +216,9 @@ export function ChatInterface({
       return;
     }
     if (currentY > touchStartYRef.current) {
-      stopFollowingLatest();
+      cancelPendingScroll();
     }
-  }, [stopFollowingLatest]);
+  }, [cancelPendingScroll]);
 
   const handleTouchEnd = useCallback(() => {
     touchStartYRef.current = null;


### PR DESCRIPTION
## 问题与范围
- 聊天区在已接近或到达底部时，"回到底部"按钮仍可能错误显示。
- 本 PR 仅修复聊天区按钮显隐与自动跟随滚动逻辑，并同步更新 changelog。

## 关键改动
- web/src/components/chat/chat-interface.tsx
- CHANGELOG.md

## 验证
- cd web && npx tsc --noEmit
- cd web && npx eslint src/components/chat/chat-interface.tsx

## 备注
- 未执行浏览器级自动回归；当前环境缺少 Playwright，且安装过程受代理超时影响。