### PR TITLE
fix: #7 agent/config/config.py 在 Python 3.14 下因无效转义序列无法通过严格编译检查

### DIFF
--- a/agent/config/config.py
+++ b/agent/config/config.py
@@ -25,7 +25,7 @@ else:
     ENV_FILE = os.path.join(ROOT_PATH, "../.env")
 
 # http://patorjk.com/software/taag/#p=display&f=Lil%20Devil&t=v%201.0.1%0A
-logo = """
+logo = r"""
 
      (`-')  _            (`-')  _<-. (`-')_ (`-')              <-.(`-')  _     (`-')      
      (OO ).-/     .->    ( OO).-/   \( OO) )( OO).->            __( OO) (_)    ( OO).->   


### PR DESCRIPTION
## Summary

Make the ASCII logo banner a raw string so Python 3.14 no longer treats  as an invalid escape sequence during strict compilation.

## Changes

- changed  in  from a normal triple-quoted string to a raw triple-quoted string
- preserved banner contents and runtime behavior

## Testing

- 
- 

Fixes nexus-research-lab/nexus-core#7