### PR TITLE
fix: #12 make check-backend fails in a clean environment because the Makefile hard-depends on rg

### DIFF
--- a/makefile
+++ b/makefile
@@ -79,11 +79,11 @@ install: ## Install all dependencies
 
 check-backend: ## Run backend syntax check
 	@if [ -x .venv/bin/python ]; then \
-		.venv/bin/python -m py_compile $$(rg --files agent -g '*.py'); \
+		.venv/bin/python -m py_compile $$(find agent -type f -name '*.py'); \
 	elif command -v python3 >/dev/null 2>&1; then \
-		python3 -m py_compile $$(rg --files agent -g '*.py'); \
+		python3 -m py_compile $$(find agent -type f -name '*.py'); \
 	elif command -v python >/dev/null 2>&1; then \
-		python -m py_compile $$(rg --files agent -g '*.py'); \
+		python -m py_compile $$(find agent -type f -name '*.py'); \
 	else \
 		echo "No usable Python runtime found"; \
 		exit 1; \


### PR DESCRIPTION
## Summary

Remove the implicit ripgrep dependency from `make check-backend` so the backend syntax check works in clean environments without `rg` installed.

## Changes

- replace `rg --files agent -g '*.py'` with `find agent -type f -name '*.py'` in `check-backend`\n- keep the existing Python runtime fallback behavior unchanged\n\n## Testing\n\n- ran `make check-backend` in an environment without `rg` installed\n- verified the target now exits successfully instead of failing before `py_compile` runs\n\nFixes #12