### PR TITLE
fix: mount health check route in router (#5)

### DIFF
--- a/agent/api/router.py
+++ b/agent/api/router.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends
 
 from agent.api.agent.api_agent import router as agent_router
 from agent.api.chat_ws.websocket_server import router as websocket_router
+from agent.api.common.api import common_router
 from agent.api.repository.api_persistence import router as persistence_router
 from agent.api.room.api_room import router as room_router
 from agent.api.session.api_session import router as session_router
@@ -35,3 +36,6 @@ api_router.include_router(room_router, prefix="/v1")
 
 # Include the persistence router
 api_router.include_router(persistence_router, prefix="/v1")
+
+# Include the common router (health check, etc.)
+api_router.include_router(common_router)


### PR DESCRIPTION
Fixes #5

The common_router (defined in agent/api/common/api.py) was never mounted in agent/api/router.py, causing GET /health to return 404.

This change imports and mounts common_router so /health returns {"status": "ok"}.