### PR TITLE
fix: #24 修复 all_files ?? [] 导致 useMemo 失效

### DIFF
--- a/web/src/features/room-conversation/room-workspace-view.tsx
+++ b/web/src/features/room-conversation/room-workspace-view.tsx
@@ -183,8 +183,8 @@ export function RoomWorkspaceView({
   const files_by_agent = useWorkspaceFilesStore((state) => state.files_by_agent);
 
   const view_agent_id = is_dm ? agent_id : selected_agent_id;
-  const all_files = files_by_agent[view_agent_id] ?? [];
-  const tree = useMemo(() => buildTree(all_files), [all_files]);
+  const all_files = files_by_agent[view_agent_id];
+  const tree = useMemo(() => buildTree(all_files ?? []), [all_files]);
 
   const handle_click_file = useCallback(
     (path: string) => on_open_workspace_file(path),


### PR DESCRIPTION
## 修复内容

修复 `room-workspace-view.tsx` 中 `all_files ?? []` 每次渲染创建新数组引用导致 `useMemo` 失效的问题。

### 改动

将 `?? []` 从 `useMemo` 外部移入内部回调，依赖项改为 `files_by_agent[view_agent_id]`，避免空数组新引用触发无意义重计算。

### 关联

Closes #24