### PR TITLE
fix: #25 修正 credentials 字段误导注释，标注明文存储现状

### DIFF
--- a/agent/infra/database/models/connector.py
+++ b/agent/infra/database/models/connector.py
@@ -29,7 +29,7 @@ class ConnectorConnection(TimestampMixin, Base):
     connector_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     # 连接状态：connected / disconnected / expired
     state: Mapped[str] = mapped_column(String(32), default="disconnected", nullable=False)
-    # 授权凭证（加密存储），JSON 格式
+    # 授权凭证，JSON 格式（当前明文存储，后续需加密，见 connector_service.py）
     credentials: Mapped[str] = mapped_column(Text, default="", nullable=False)
     # 授权方式
     auth_type: Mapped[str] = mapped_column(String(32), default="oauth2", nullable=False)

--- a/agent/service/capability/connectors/connector_service.py
+++ b/agent/service/capability/connectors/connector_service.py
@@ -135,6 +135,7 @@ class ConnectorService:
         # 中文注释：OAuth 完成后清空临时 state，只保留第三方返回的 token 结果。
         await connector_repository.connect(
             connector_id=connection.connector_id,
+            # TODO: 加密凭证后再存储，当前为明文，存在安全风险（见 #25）
             credentials=json.dumps(token_payload, ensure_ascii=False),
             auth_type=entry.auth_type,
             state="connected",


### PR DESCRIPTION
## 修复内容

Issue #25 指出 `credentials` 字段注释写「加密存储」但实际明文存储，具有误导性。

### 改动

- `agent/infra/database/models/connector.py`：注释从「加密存储」改为「当前明文存储，后续需加密」
- `agent/service/capability/connectors/connector_service.py`：在凭证写入处添加 `TODO` 标记

### 未包含（留作后续）

实际加密实现（使用 fernet 对称加密 + 环境变量密钥）需要引入新依赖和迁移方案，不在本次 PR 范围内。

### 关联

Related #25