### PR TITLE
fix: #30 pyproject.toml classifiers 声明 Python 3.10 与 requires-python 不一致

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [{ name = "leemysw" }]
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## 修复内容

Closes #30

删除 `pyproject.toml` 中 `"Programming Language :: Python :: 3.10"` classifier，与 `requires-python = ">=3.11"` 保持一致。

## 改动

- 删除 1 行 classifier

## 风险

零风险。纯声明修正。