### PR TITLE
fix: #29 requirements.txt 中 alembic 重复声明

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -7,7 +7,6 @@ websockets>=15
 pydantic>=2.6.0
 pydantic-settings>=2.12.0
 typer>=0.20.0
-alembic>=1.14.0
 python-dotenv>=1.0.0
 python-multipart>=0.0.20
 typing_inspect


### PR DESCRIPTION
## 修复内容

Closes #29

删除 `agent/requirements.txt` 中重复的 `alembic>=1.14.0`（第 10 行），保留更严格的 `alembic>=1.18.4`。

## 改动

- 删除 1 行重复依赖

## 风险

零风险。pip 行为不变。