### PR TITLE
fix: #34 base_task.repeat_every 异常处理引用未定义变量 exc

### DIFF
--- a/agent/infra/server/common/base_task.py
+++ b/agent/infra/server/common/base_task.py
@@ -97,7 +97,7 @@ def repeat_every(
                     try:
                         await _handle_func(func)
 
-                    except Exception as e:
+                    except Exception as exc:
                         if logger is not None:
                             warnings.warn(
                                 "'logger' is to be deprecated in favor of 'on_exception' in the 1.0 release.",


### PR DESCRIPTION
## 修复内容

修复 `base_task.py` 中 `repeat_every` 装饰器的异常变量命名不一致问题。

**问题：** `except Exception as e:` 捕获异常为 `e`，但后续代码全部引用 `exc`，导致运行时 `NameError`。

**修复：** 将 `except Exception as e` 改为 `except Exception as exc`，使所有下游引用自然正确。

Closes #34