### PR TITLE
fix: #34 base_task.repeat_every 异常处理引用未定义变量

### DIFF
--- a/agent/infra/server/common/base_task.py
+++ b/agent/infra/server/common/base_task.py
@@ -97,7 +97,7 @@ def repeat_every(
                     try:
                         await _handle_func(func)
 
-                    except Exception as e:
+                    except Exception as exc:
                         if logger is not None:
                             warnings.warn(
                                 "'logger' is to be deprecated in favor of 'on_exception' in the 1.0 release.",


### PR DESCRIPTION
## 修复内容

将 `repeat_every` 中 `except Exception as e:` 改为 `except Exception as exc:`，使其与后续 `format_exception(type(exc), exc, exc.__traceback__)`、`raise exc`、`_handle_exc(exc, ...)` 引用一致。

修复前：捕获为 `e` 但引用 `exc`（NameError）。
修复后：变量名统一为 `exc`。

Closes #34