### PR TITLE
fix: #38 Settings.__str__() 未脱敏敏感配置

### DIFF
--- a/agent/config/config.py
+++ b/agent/config/config.py
@@ -186,11 +186,12 @@ class Settings(BaseSettings):
     def __str__(self):
         text = "\n".join(
             [
-                attr + ": " + str(getattr(self, attr))
+                attr + ": " + str(self._mask_sensitive_value(attr, getattr(self, attr)))
                 for attr in dir(self)
                 if not attr.startswith("__") and
                 not callable(getattr(self, attr)) and
-                attr not in ["LOGO", "SECRET_KEY"]
+                attr not in ["LOGO", "SECRET_KEY", "_abc_impl"] and
+                not attr.startswith("model_")
             ]
         )
         return "\n" + text


### PR DESCRIPTION
## 修复内容

1. `__str__()` 中调用 `_mask_sensitive_value()` 脱敏敏感字段（TOKEN、SECRET 等）
2. 补充过滤 `_abc_impl` 和 `model_*` 属性，与 `status()` 方法保持一致

Closes #38