### PR TITLE
fix: #24 RoomWorkspaceView useMemo 因 ?? [] 每次创建新引用而失效

### DIFF
--- a/web/src/features/room-conversation/room-workspace-view.tsx
+++ b/web/src/features/room-conversation/room-workspace-view.tsx
@@ -183,8 +183,8 @@ export function RoomWorkspaceView({
   const files_by_agent = useWorkspaceFilesStore((state) => state.files_by_agent);
 
   const view_agent_id = is_dm ? agent_id : selected_agent_id;
-  const all_files = files_by_agent[view_agent_id] ?? [];
-  const tree = useMemo(() => buildTree(all_files), [all_files]);
+  const all_files = files_by_agent[view_agent_id];
+  const tree = useMemo(() => buildTree(all_files ?? []), [files_by_agent, view_agent_id]);
 
   const handle_click_file = useCallback(
     (path: string) => on_open_workspace_file(path),


### PR DESCRIPTION
## 修复内容

将 `all_files` 的 fallback `?? []` 移入 `useMemo` 回调内部，依赖项改为 `[files_by_agent, view_agent_id]`，避免每次渲染创建新数组引用导致 `useMemo` 失效。

Closes #24