### PR TITLE
fix: #66 isolate web as nested Go module

### DIFF
--- a/web/go.mod
+++ b/web/go.mod
@@ -1,0 +1,3 @@
+module github.com/nexus-research-lab/nexus/web
+
+go 1.26.2


### PR DESCRIPTION
## Summary

Isolate the frontend `web/` tree as its own Go module so root-level `go test ./...` package discovery no longer descends into `web/node_modules` after frontend dependencies are installed.

## Changes

- add `web/go.mod`
- keep the root backend module unchanged
- rely on Go module boundaries instead of maintaining a fragile hard-coded package allowlist

## Testing

- validated that with `web/go.mod` present, root-module package discovery no longer includes a synthetic Go package placed under `web/node_modules`
- validated the inverse: without `web/go.mod`, the same synthetic package is discovered by root-module package discovery
- repository-wide Go build/test is still blocked separately by existing issues #64 and #65

Fixes #66
