### PR TITLE
fix: #68 Bug: publish workflow still installs removed agent/requirements.txt and fails before release build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,22 +41,12 @@ jobs:
         run: |
           git checkout "${{ steps.tag.outputs.tag }}"
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
-
-      - name: Install Backend Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r agent/requirements.txt
 
       - name: Install Web Dependencies
         run: |


### PR DESCRIPTION
## Summary
- remove stale Python setup from release workflow
- stop installing removed `agent/requirements.txt` during release
- keep the release pipeline aligned with the current repo layout

## Testing
- `cd web && npm ci`
- `cd web && npm run lint` (passes with one pre-existing warning)
- `cd web && npx tsc --noEmit`
- `cd web && npm run build`
- `go mod download` still fails due to existing `go.mod` local replace path issue tracked separately in #64

Fixes #68