### PR TITLE
fix: #70 Build/Docs: clean checkout still cannot fetch private nexus-agent-sdk-go after removing local replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,34 @@ DATABASE_URL=sqlite:////$HOME/.nexus/data/nexus.db
 
 ### 3. 安装
 
+#### Private Go SDK dependency
+
+当前后端依赖私有模块 `github.com/nexus-research-lab/nexus-agent-sdk-go`。
+在干净环境执行 `make install` 前，至少需要先满足下面三个前提：
+
+1. `go.mod` 里不能保留开发机本地绝对路径的 `replace github.com/nexus-research-lab/nexus-agent-sdk-go => /...`
+2. Go 需要把该组织下模块视为私有模块：
+   ```bash
+   go env -w GOPRIVATE=github.com/nexus-research-lab/*
+   go env -w GONOSUMDB=github.com/nexus-research-lab/*
+   ```
+3. Git 需要具备对 `github.com/nexus-research-lab/*` 的非交互访问能力（PAT 或 SSH 任选其一）
+
+PAT 示例：
+
+```bash
+git config --global url."https://<github-token>@github.com/".insteadOf https://github.com/
+```
+
+SSH 示例：
+
+```bash
+git config --global url."git@github.com:".insteadOf https://github.com/
+ssh -T git@github.com
+```
+
+如果上述前提未满足，`make install` 会在执行 `go mod download` 之前直接失败，并给出明确提示，而不是在更深层的位置报模糊的 GitHub 认证错误。
+
 ```bash
 make install
 ```

--- a/makefile
+++ b/makefile
@@ -12,6 +12,7 @@ AGENT_UID ?= 1001
 AGENT_GID ?= 1001
 HOST_SUDO ?= sudo
 COMPOSE_CMD ?= docker compose --env-file $(ENV_FILE) -f deploy/docker-compose.yml
+PRIVATE_SDK_MODULE ?= github.com/nexus-research-lab/nexus-agent-sdk-go
 
 # Default target
 .DEFAULT_GOAL := help
@@ -77,6 +78,26 @@ dev: ## Run both frontend and backend in development mode
 install: ## Install all dependencies
 	@echo "Installing Go dependencies..."
 	@if command -v go >/dev/null 2>&1; then \
+		if grep -q "^replace $(PRIVATE_SDK_MODULE) => /" go.mod; then \
+			echo "Error: go.mod still contains a local replace for $(PRIVATE_SDK_MODULE)."; \
+			echo "The current main branch expects access to a private SDK repository and cannot be installed from a clean environment until that replace is removed or the dependency strategy is updated."; \
+			echo "See README.md -> Private Go SDK dependency for the required GitHub / GOPRIVATE setup and current limitations."; \
+			exit 1; \
+		fi; \
+		go env GOPRIVATE | tr ',' '\n' | grep -Fxq "github.com/nexus-research-lab/*" || { \
+			echo "Error: GOPRIVATE is not configured for github.com/nexus-research-lab/*."; \
+			echo "Set GOPRIVATE (and usually GONOSUMDB) before running make install:"; \
+			echo "  go env -w GOPRIVATE=github.com/nexus-research-lab/*"; \
+			echo "  go env -w GONOSUMDB=github.com/nexus-research-lab/*"; \
+			echo "See README.md -> Private Go SDK dependency for details."; \
+			exit 1; \
+		}; \
+		git config --get-regexp '^url\..*github\.com[:/]nexus-research-lab/' >/dev/null 2>&1 || { \
+			echo "Error: git is not configured with non-interactive credentials for github.com/nexus-research-lab/."; \
+			echo "Configure a PAT or SSH access before running make install."; \
+			echo "See README.md -> Private Go SDK dependency for examples."; \
+			exit 1; \
+		}; \
 		go mod download; \
 	else \
 		echo "No usable Go runtime found"; \


### PR DESCRIPTION
## Summary

Add explicit install prerequisites for the private Go SDK and fail fast in `make install` when those prerequisites are not met.

## Changes

- document the private `nexus-agent-sdk-go` dependency in README
- document required `GOPRIVATE` / `GONOSUMDB` setup and non-interactive Git auth examples
- add `make install` preflight checks for local `replace`, missing `GOPRIVATE`, and missing Git credential setup
- surface actionable error messages before `go mod download` fails deep in Git auth

## Testing

- `make help`
- `make install` (verified new fast-fail message for local `replace` in clean worktree)

Fixes nexus-research-lab/nexus-core#70