### PR TITLE
fix: #49

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# 中文注释：统一把仓库根目录注入 sys.path，确保直接执行 pytest 时也能导入 agent 包。
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary

Retarget existing \ work to \, which is the correct Python code line.

## Changes

Reuses the existing minimal fix already pushed on \.

Fixes #49
