### PR TITLE
fix: #79 Tests: go test ./... still fails because chat/room tests reference removed sdkprotocol block types

### DIFF
--- a/internal/chat/mapper_test.go
+++ b/internal/chat/mapper_test.go
@@ -229,7 +229,7 @@ func TestMessageMapperMapsToolResultMessage(t *testing.T) {
 		Assistant: &sdkprotocol.AssistantMessage{
 			Message: sdkprotocol.ConversationEnvelope{
 				Content: []sdkprotocol.ContentBlock{
-					sdkprotocol.ToolUseBlock{ID: "tool-mapper-1", Name: "WebSearch"},
+					{Type: "tool_use", ID: "tool-mapper-1", Name: "WebSearch"},
 				},
 			},
 		},
@@ -240,7 +240,8 @@ func TestMessageMapperMapsToolResultMessage(t *testing.T) {
 		User: &sdkprotocol.UserMessage{
 			Message: sdkprotocol.ConversationEnvelope{
 				Content: []sdkprotocol.ContentBlock{
-					sdkprotocol.ToolResultBlock{
+					{
+						Type:      "tool_result",
 						ToolUseID: "tool-mapper-1",
 						Content:   json.RawMessage(`"搜索结果"`),
 						IsError:   false,

--- a/internal/chat/service_test.go
+++ b/internal/chat/service_test.go
@@ -174,7 +174,7 @@ func TestServiceHandleChatPersistsMessages(t *testing.T) {
 						ID:    "assistant-1",
 						Model: "sonnet",
 						Content: []sdkprotocol.ContentBlock{
-							sdkprotocol.TextBlock{Text: "你好，世界"},
+							{Type: "text", Text: "你好，世界"},
 						},
 					},
 				},
@@ -356,7 +356,7 @@ func TestServiceHandleChatKeepsThinkingDuringStreamingAndHistoryReplay(t *testin
 						ID:    "assistant-think-1",
 						Model: "sonnet",
 						Content: []sdkprotocol.ContentBlock{
-							sdkprotocol.TextBlock{Text: "今天天气 很不错"},
+							{Type: "text", Text: "今天天气 很不错"},
 						},
 					},
 				},

--- a/internal/room/message_mapper_test.go
+++ b/internal/room/message_mapper_test.go
@@ -147,7 +147,7 @@ func TestSlotMessageMapperMapsToolResultMessage(t *testing.T) {
 		Assistant: &sdkprotocol.AssistantMessage{
 			Message: sdkprotocol.ConversationEnvelope{
 				Content: []sdkprotocol.ContentBlock{
-					sdkprotocol.ToolUseBlock{ID: "tool-room-1", Name: "WebSearch"},
+					{Type: "tool_use", ID: "tool-room-1", Name: "WebSearch"},
 				},
 			},
 		},
@@ -158,7 +158,8 @@ func TestSlotMessageMapperMapsToolResultMessage(t *testing.T) {
 		User: &sdkprotocol.UserMessage{
 			Message: sdkprotocol.ConversationEnvelope{
 				Content: []sdkprotocol.ContentBlock{
-					sdkprotocol.ToolResultBlock{
+					{
+						Type:      "tool_result",
 						ToolUseID: "tool-room-1",
 						Content:   json.RawMessage(`"Room 搜索结果"`),
 						IsError:   false,

--- a/internal/room/realtime_service_test.go
+++ b/internal/room/realtime_service_test.go
@@ -167,7 +167,7 @@ func TestRealtimeServiceHandleChatWithDirectRoomFallbackTarget(t *testing.T) {
 						ID:    "assistant-sdk-1",
 						Model: "sonnet",
 						Content: []sdkprotocol.ContentBlock{
-							sdkprotocol.TextBlock{Text: "已收到，正在处理。"},
+							{Type: "text", Text: "已收到，正在处理。"},
 						},
 					},
 				},
@@ -421,7 +421,7 @@ func TestRealtimeServiceKeepsThinkingDuringStreamingAndHistoryReplay(t *testing.
 						ID:    "assistant-room-think-1",
 						Model: "sonnet",
 						Content: []sdkprotocol.ContentBlock{
-							sdkprotocol.TextBlock{Text: "今天天气 很不错"},
+							{Type: "text", Text: "今天天气 很不错"},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Update the remaining chat/room tests that still constructed removed typed SDK blocks, so they match the current unified ContentBlock protocol shape used by the runtime code.

## Changes

- replace legacy sdkprotocol.TextBlock test fixtures with sdkprotocol.ContentBlock{Type: "text", ...}
- replace legacy sdkprotocol.ToolUseBlock fixtures with sdkprotocol.ContentBlock{Type: "tool_use", ...}
- replace legacy sdkprotocol.ToolResultBlock fixtures with sdkprotocol.ContentBlock{Type: "tool_result", ...}
- keep the existing tool result payload semantics intact in mapper tests

## Testing

- go test ./internal/chat ./internal/room
- go test ./...
- make check (passes after installing missing web dependencies locally; existing lint warning remains in web/src/features/capability/scheduled/dialog/use-scheduled-task-dialog-state.ts)

Fixes nexus-research-lab/nexus#79
