### PR TITLE
fix: #87 #88 auth setup mode + auto-migrate on server boot

### DIFF
--- a/cmd/nexus-server/main.go
+++ b/cmd/nexus-server/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -12,7 +14,37 @@ import (
 	"github.com/nexus-research-lab/nexus/internal/config"
 	"github.com/nexus-research-lab/nexus/internal/gateway"
 	"github.com/nexus-research-lab/nexus/internal/logx"
+	"github.com/nexus-research-lab/nexus/internal/storage"
+
+	"github.com/pressly/goose/v3"
 )
+
+func runMigrations(cfg config.Config, logger *slog.Logger) error {
+	driver := storage.NormalizeSQLDriver(cfg.DatabaseDriver)
+	dsn := storage.NormalizeDatabaseURL(cfg.DatabaseURL)
+	dir := "db/migrations/" + storage.MigrationDirName(cfg.DatabaseDriver)
+
+	db, err := sql.Open(driver, dsn)
+	if err != nil {
+		return fmt.Errorf("open db for migration: %w", err)
+	}
+	defer db.Close()
+
+	if err = goose.SetDialect(storage.GooseDialect(cfg.DatabaseDriver)); err != nil {
+		return fmt.Errorf("set goose dialect: %w", err)
+	}
+
+	version, err := goose.GetDBVersion(db)
+	if err != nil {
+		logger.Info("无法获取当前 migration 版本，尝试初始化", "err", err)
+	}
+
+	logger.Info("执行数据库迁移", "current_version", version, "dir", dir)
+	if err = goose.Up(db, dir); err != nil {
+		return fmt.Errorf("run goose up: %w", err)
+	}
+	return nil
+}
 
 func main() {
 	cfg := config.Load()
@@ -32,6 +64,13 @@ func main() {
 			Compress:    cfg.LogCompress,
 		},
 	})
+
+	// 自动运行 schema migrations，确保首次启动或升级时数据库 schema 就绪。
+	if err := runMigrations(cfg, logger); err != nil {
+		logger.Error("数据库迁移失败", "err", err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	server, err := gateway.NewServerWithLogger(cfg, logger)
 	if err != nil {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -435,7 +435,7 @@ func (s *Service) buildStatusPayload(state State, principal *Principal) StatusPa
 	result := StatusPayload{
 		AuthRequired:         state.AuthRequired,
 		PasswordLoginEnabled: state.PasswordLoginEnabled,
-		Authenticated:        !state.AuthRequired,
+		Authenticated:        !state.AuthRequired && !state.SetupRequired,
 		SetupRequired:        state.SetupRequired,
 		AccessTokenEnabled:   state.AccessTokenEnabled,
 	}

--- a/internal/gateway/auth/handlers.go
+++ b/internal/gateway/auth/handlers.go
@@ -132,7 +132,7 @@ func (h *Handlers) HandleAuthLogout(writer http.ResponseWriter, request *http.Re
 	h.api.WriteSuccess(writer, authsvc.StatusPayload{
 		AuthRequired:         state.AuthRequired,
 		PasswordLoginEnabled: state.PasswordLoginEnabled,
-		Authenticated:        !state.AuthRequired,
+		Authenticated:        !state.AuthRequired && !state.SetupRequired,
 		Username:             nil,
 		SetupRequired:        state.SetupRequired,
 		AccessTokenEnabled:   state.AccessTokenEnabled,

--- a/internal/gateway/auth/profile.go
+++ b/internal/gateway/auth/profile.go
@@ -154,7 +154,7 @@ func buildPersonalUserPayload(principal *authsvc.Principal) personalUserPayload 
 			UserID:      authsvc.SystemUserID,
 			Username:    "local",
 			DisplayName: "Local User",
-			Role:        authsvc.RoleOwner,
+			Role:        authsvc.RoleMember,
 			Avatar:      "",
 			AuthMethod:  "",
 		}


### PR DESCRIPTION
## Fixes

- **fix #87**: Fresh uninitialized instance exposes protected routes without authentication
  - `buildStatusPayload`: `Authenticated = !AuthRequired && !SetupRequired`
  - `buildPersonalUserPayload(nil)`: Role changed from `owner` to `member`
  - `HandleAuthLogout`: same Authenticated logic

- **fix #88**: nexus-server cold-start crash on fresh DB
  - `cmd/nexus-server/main.go`: auto-run goose migrations before gateway init
  - Ensures fresh DB gets schema before any service queries tables

## Testing
- `go test ./internal/auth/... ./internal/gateway/...` pass
- `go build ./cmd/nexus-server` pass