### PR TITLE
fix: #86 heartbeat start gracefully when automation_heartbeat_states table missing

### DIFF
--- a/agent/service/automation/heartbeat/heartbeat_service.py
+++ b/agent/service/automation/heartbeat/heartbeat_service.py
@@ -92,7 +92,15 @@ class HeartbeatService:
 
     async def start(self) -> None:
         """启动 heartbeat 运行态。"""
-        rows = await self._state_store.list_enabled_states()
+        try:
+            rows = await self._state_store.list_enabled_states()
+        except Exception as exc:
+            # 未迁移数据库时表不存在，降级为空列表启动，避免拖垮整个 app lifespan
+            from sqlalchemy.exc import OperationalError
+            if isinstance(exc, OperationalError) and "no such table" in str(exc).lower():
+                rows = []
+            else:
+                raise
         for row in rows:
             config, _delivery_error = self._config_from_row(row)
             await self._scheduler.sync_agent(config.agent_id, config)


### PR DESCRIPTION
## Fix

- **fix #86**: Fresh SQLite startup fails before migrations because heartbeat service queries automation_heartbeat_states during app lifespan
  - `heartbeat_service.py` `start()`: catch `sqlalchemy.exc.OperationalError` with "no such table"
  - Degrade to empty list, preventing app lifespan crash on fresh DB

## Testing
- Verified the exception handling path compiles and matches the reported error signature.