### PR TITLE
fix: #95 Room realtime queue scheduling has a data race on activeRoomSlot.Status and fails go test -race

### DIFF
--- a/internal/service/room/realtime_execution.go
+++ b/internal/service/room/realtime_execution.go
@@ -85,7 +85,7 @@ func (s *RealtimeService) runSlot(
 	agentValue *protocol.Agent,
 ) {
 	if agentValue == nil {
-		slot.Status = "error"
+		slot.setStatus("error")
 		s.loggerFor(ctx).Error("Room slot 缺少 agent 配置",
 			"session_key", roundValue.SessionKey,
 			"room_id", roundValue.RoomID,
@@ -108,7 +108,7 @@ func (s *RealtimeService) runSlot(
 		"msg_id", slot.MsgID,
 	)
 	mapper := roomdomain.NewSlotMessageMapper(roundValue.SessionKey, roundValue.RoomID, roundValue.ConversationID, slot.AgentID, slot.MsgID, slot.AgentRoundID)
-	slot.Status = "running"
+	slot.setStatus("running")
 	logger.Info("开始执行 Room slot")
 	defer s.finishSlot(slot)
 
@@ -155,7 +155,7 @@ func (s *RealtimeService) runSlot(
 		DisallowedTools:    agentValue.Options.DisallowedTools,
 		SettingSources:     agentValue.Options.SettingSources,
 		AppendSystemPrompt: appendSystemPrompt,
-		ResumeSessionID:    slot.SDKSessionID,
+		ResumeSessionID:    slot.getSDKSessionID(),
 		MaxThinkingTokens:  agentValue.Options.MaxThinkingTokens,
 		MaxTurns:           agentValue.Options.MaxTurns,
 		MCPServers:         mcpServers,
@@ -179,7 +179,7 @@ func (s *RealtimeService) runSlot(
 		logger.Warn("Agent SDK stderr", "stderr", line)
 	}
 	client := s.factory.New(options)
-	slot.Client = client
+	slot.setClient(client)
 
 	if err := client.Connect(slotCtx); err != nil {
 		s.handleSlotFailure(slotCtx, roundValue, slot, mapper, err)
@@ -216,7 +216,7 @@ func (s *RealtimeService) runSlot(
 		s.handleSlotFailure(slotCtx, roundValue, slot, mapper, err)
 		return
 	}
-	slot.NoReplyCandidate = true
+	slot.beginNoReplyCandidate()
 	result, err := runtimectx.ExecuteRound(slotCtx, runtimectx.RoundExecutionRequest{
 		Query:  dispatchPrompt,
 		Client: client,
@@ -247,14 +247,14 @@ func (s *RealtimeService) runSlot(
 		HandleDurableMessage: func(messageValue protocol.Message) error {
 			messageRole := protocol.MessageRole(messageValue)
 			if messageRole == "result" {
-				slot.Status = resultStatus(messageValue["subtype"])
+				slot.setStatus(resultStatus(messageValue["subtype"]))
 				s.recordUsage(roundValue, messageValue)
 			}
 			if messageRole == "assistant" && roomdomain.IsNoReplyAssistantMessage(messageValue) {
-				slot.SuppressOutput = true
+				slot.suppressOutput()
 				return nil
 			}
-			if slot.SuppressOutput {
+			if slot.shouldSuppressOutput() {
 				return nil
 			}
 			if err := s.persistSharedDurableMessage(roundValue.ConversationID, slot, messageValue); err != nil {
@@ -268,7 +268,7 @@ func (s *RealtimeService) runSlot(
 			return nil
 		},
 		EmitEvent: func(event protocol.EventMessage) error {
-			for _, readyEvent := range roomEventsReadyForEmission(slot, event) {
+			for _, readyEvent := range slot.eventsReadyForEmission(event) {
 				s.broadcastSharedEventWithTimeout(slotCtx, roundValue.SessionKey, roundValue.RoomID, readyEvent)
 			}
 			return nil
@@ -283,10 +283,10 @@ func (s *RealtimeService) runSlot(
 		return
 	}
 
-	if slot.Status == "running" {
-		slot.Status = resultStatus(result.ResultSubtype)
+	if slot.getStatus() == "running" {
+		slot.setStatus(resultStatus(result.ResultSubtype))
 	}
-	if !slot.SuppressOutput {
+	if !slot.shouldSuppressOutput() {
 		if err := s.collectPublicMentionWakes(slotCtx, roundValue, slot, mapper.LastAssistantMessage()); err != nil {
 			s.handleSlotFailure(slotCtx, roundValue, slot, mapper, err)
 			return
@@ -301,7 +301,7 @@ func (s *RealtimeService) runSlot(
 		slot.MsgID,
 		slot.AgentRoundID,
 	))
-	logger.Info("Room slot 结束", "status", slot.Status)
+	logger.Info("Room slot 结束", "status", slot.getStatus())
 }
 
 func (s *RealtimeService) recordUsage(roundValue *activeRoomRound, message protocol.Message) {
@@ -322,10 +322,9 @@ func (s *RealtimeService) recordUsage(roundValue *activeRoomRound, message proto
 
 func (s *RealtimeService) syncSlotSDKSessionID(ctx context.Context, slot *activeRoomSlot, sessionID string) error {
 	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" || sessionID == strings.TrimSpace(slot.SDKSessionID) {
+	if !slot.setSDKSessionID(sessionID) {
 		return nil
 	}
-	slot.SDKSessionID = sessionID
 	if s.rooms == nil {
 		return nil
 	}
@@ -344,7 +343,7 @@ func (s *RealtimeService) handleSlotFailure(ctx context.Context, roundValue *act
 	}
 	fields = append(fields, roomSlotFailureDiagnostics(err, slot, mapper)...)
 	s.loggerFor(ctx).Error("Room slot 执行失败", fields...)
-	slot.Status = "error"
+	slot.setStatus("error")
 	resultMessage := protocol.Message{
 		"message_id":      "result_" + slot.AgentRoundID,
 		"session_key":     roundValue.SessionKey,
@@ -425,8 +424,8 @@ func roomSlotFailureDiagnostics(err error, slot *activeRoomSlot, mapper *roomdom
 			"last_assistant_chars", utf8.RuneCountInString(strings.TrimSpace(roomdomain.ExtractHistoryText(lastAssistant))),
 		)
 	}
-	if slot != nil && slot.Client != nil {
-		fields = append(fields, "client_session_id", slot.Client.SessionID())
+	if client := slot.getClient(); client != nil {
+		fields = append(fields, "client_session_id", client.SessionID())
 	}
 	return fields
 }
@@ -449,11 +448,7 @@ func (s *RealtimeService) handleSlotCancelled(ctx context.Context, roundValue *a
 }
 
 func (s *RealtimeService) markSlotCancelled(slot *activeRoomSlot) bool {
-	if slot == nil || slot.Status == "cancelled" {
-		return false
-	}
-	slot.Status = "cancelled"
-	return true
+	return slot != nil && slot.markCancelled()
 }
 
 func (s *RealtimeService) broadcastSlotCancelled(ctx context.Context, roundValue *activeRoomRound, slot *activeRoomSlot) {
@@ -491,8 +486,8 @@ func (s *RealtimeService) emitInterruptedSlotResult(roundValue *activeRoomRound,
 	if trimmedResult := strings.TrimSpace(resultText); trimmedResult != "" {
 		resultMessage["result"] = trimmedResult
 	}
-	if slot.Client != nil {
-		if sessionID := strings.TrimSpace(slot.Client.SessionID()); sessionID != "" {
+	if client := slot.getClient(); client != nil {
+		if sessionID := strings.TrimSpace(client.SessionID()); sessionID != "" {
 			resultMessage["session_id"] = sessionID
 		}
 	}
@@ -555,7 +550,7 @@ func (s *RealtimeService) persistPrivateOverlayMessage(slot *activeRoomSlot, mes
 	}
 	privateMessage := normalizePrivateOverlayMessage(cloneMessageWithSessionKey(message, slot.RuntimeSessionKey))
 	privateMessage["session_key"] = slot.RuntimeSessionKey
-	if sessionID := firstNonEmpty(strings.TrimSpace(anyString(privateMessage["session_id"])), strings.TrimSpace(slot.SDKSessionID)); sessionID != "" {
+	if sessionID := firstNonEmpty(strings.TrimSpace(anyString(privateMessage["session_id"])), slot.getSDKSessionID()); sessionID != "" {
 		privateMessage["session_id"] = sessionID
 	}
 	if strings.TrimSpace(anyString(privateMessage["message_id"])) == "" {

--- a/internal/service/room/realtime_guidance_message.go
+++ b/internal/service/room/realtime_guidance_message.go
@@ -27,7 +27,7 @@ func buildRoomGuidanceMessage(
 		AgentRoundID:   slot.AgentRoundID,
 		SourceRoundID:  sourceRoundID,
 		Content:        content,
-		SDKSessionID:   slot.SDKSessionID,
+		SDKSessionID:   slot.getSDKSessionID(),
 	})
 }
 

--- a/internal/service/room/realtime_interrupt.go
+++ b/internal/service/room/realtime_interrupt.go
@@ -209,9 +209,9 @@ func (s *RealtimeService) interruptActiveSlot(
 	}
 	interruptReason := normalizeRoomInterruptReason(message)
 	markRoomSlotInterrupted(slot, interruptReason)
-	shouldBroadcast := slot.Status != "finished" && slot.Status != "error" && slot.Status != "cancelled"
-	if slot.Client != nil {
-		if err := slot.Client.Interrupt(ctx); err != nil && !suppressError {
+	shouldBroadcast := !slot.isTerminal()
+	if client := slot.getClient(); client != nil {
+		if err := client.Interrupt(ctx); err != nil && !suppressError {
 			return err
 		}
 	}
@@ -264,8 +264,8 @@ func (s *RealtimeService) interruptActiveRound(
 	interruptReason := normalizeRoomInterruptReason(message)
 	for _, slot := range roundValue.Slots {
 		markRoomSlotInterrupted(slot, interruptReason)
-		if slot.Client != nil {
-			if err := slot.Client.Interrupt(ctx); err != nil && !suppressError {
+		if client := slot.getClient(); client != nil {
+			if err := client.Interrupt(ctx); err != nil && !suppressError {
 				return err
 			}
 		}

--- a/internal/service/room/realtime_no_reply.go
+++ b/internal/service/room/realtime_no_reply.go
@@ -1,7 +1,6 @@
 package room
 
 import (
-	roomdomain "github.com/nexus-research-lab/nexus/internal/chat/room"
 	"github.com/nexus-research-lab/nexus/internal/protocol"
 )
 
@@ -9,34 +8,13 @@ func roomEventsReadyForEmission(slot *activeRoomSlot, event protocol.EventMessag
 	if slot == nil {
 		return []protocol.EventMessage{event}
 	}
-	if slot.SuppressOutput {
-		slot.PendingStream = nil
-		return nil
-	}
-	if shouldHoldNoReplyCandidateStream(slot, event) {
-		slot.PendingStream = append(slot.PendingStream, event)
-		return nil
-	}
-	if len(slot.PendingStream) == 0 {
-		return []protocol.EventMessage{event}
-	}
-	events := append([]protocol.EventMessage(nil), slot.PendingStream...)
-	slot.PendingStream = nil
-	events = append(events, event)
-	return events
+	return slot.eventsReadyForEmission(event)
 }
 
 func shouldHoldNoReplyCandidateStream(slot *activeRoomSlot, event protocol.EventMessage) bool {
-	if slot == nil || !slot.NoReplyCandidate {
+	if slot == nil {
 		return false
 	}
-	if event.EventType != protocol.EventTypeStream {
-		slot.NoReplyCandidate = false
-		return false
-	}
-	if roomdomain.IsNoReplyCandidateStreamEvent(event) {
-		return true
-	}
-	slot.NoReplyCandidate = false
-	return false
+	ready := slot.eventsReadyForEmission(event)
+	return len(ready) == 0
 }

--- a/internal/service/room/realtime_queue_input.go
+++ b/internal/service/room/realtime_queue_input.go
@@ -21,7 +21,8 @@ func (s *RealtimeService) queueActiveAgentSlots(
 		if slot == nil {
 			continue
 		}
-		if slot.Client == nil {
+		client := slot.getClient()
+		if client == nil {
 			slot.enqueueQueuedInput(roundID, content)
 			queuedAgentIDs[agentID] = struct{}{}
 			s.loggerFor(ctx).Info("Room 排队消息等待 slot 启动",
@@ -34,7 +35,7 @@ func (s *RealtimeService) queueActiveAgentSlots(
 			)
 			continue
 		}
-		if err := runtimectx.SendClientContent(ctx, slot.Client, strings.TrimSpace(content)); err != nil {
+		if err := runtimectx.SendClientContent(ctx, client, strings.TrimSpace(content)); err != nil {
 			return queuedAgentIDs, err
 		}
 		queuedAgentIDs[agentID] = struct{}{}
@@ -93,15 +94,7 @@ func (s *RealtimeService) findQueueSlots(
 }
 
 func isActiveQueueSlot(slot *activeRoomSlot) bool {
-	if slot == nil {
-		return false
-	}
-	switch slot.Status {
-	case "finished", "error", "cancelled":
-		return false
-	default:
-		return true
-	}
+	return slot != nil && !slot.isTerminal()
 }
 
 func filterQueuedAgentIDs(agentIDs []string, queued map[string]struct{}) []string {

--- a/internal/service/room/realtime_round_state.go
+++ b/internal/service/room/realtime_round_state.go
@@ -34,6 +34,7 @@ type activeRoomSlot struct {
 	NoReplyCandidate  bool
 	PendingStream     []protocol.EventMessage
 	Done              chan struct{}
+	stateMu           sync.RWMutex
 	inputMu           sync.Mutex
 	doneOnce          sync.Once
 }
@@ -109,7 +110,7 @@ func (s *RealtimeService) CountRunningTasks(agentID string) int {
 	count := 0
 	for _, roundValue := range s.activeRounds {
 		for _, slot := range roundValue.Slots {
-			if slot.AgentID == agentID && slot.Status != "finished" && slot.Status != "error" && slot.Status != "cancelled" {
+			if slot != nil && slot.AgentID == agentID && !slot.isTerminal() {
 				count++
 			}
 		}
@@ -135,10 +136,10 @@ func (s *RealtimeService) GetActiveRoundSnapshot(conversationID string) *ActiveR
 			snapshot.RoundID = roundValue.RoundID
 		}
 		for _, slot := range roundValue.Slots {
-			if slot == nil || slot.Status == "finished" || slot.Status == "error" || slot.Status == "cancelled" {
+			if slot == nil || slot.isTerminal() {
 				continue
 			}
-			status := slot.Status
+			status := slot.getStatus()
 			if status == "running" {
 				status = "streaming"
 			}
@@ -215,6 +216,161 @@ func (s *RealtimeService) finishSlot(slot *activeRoomSlot) {
 	})
 }
 
+func (slot *activeRoomSlot) getStatus() string {
+	if slot == nil {
+		return ""
+	}
+	slot.stateMu.RLock()
+	defer slot.stateMu.RUnlock()
+	return slot.Status
+}
+
+func (slot *activeRoomSlot) setStatus(status string) {
+	if slot == nil {
+		return
+	}
+	slot.stateMu.Lock()
+	slot.Status = status
+	slot.stateMu.Unlock()
+}
+
+func (slot *activeRoomSlot) isTerminal() bool {
+	switch slot.getStatus() {
+	case "finished", "error", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func (slot *activeRoomSlot) setSDKSessionID(sessionID string) bool {
+	if slot == nil {
+		return false
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	slot.stateMu.Lock()
+	defer slot.stateMu.Unlock()
+	if sessionID == "" || sessionID == strings.TrimSpace(slot.SDKSessionID) {
+		return false
+	}
+	slot.SDKSessionID = sessionID
+	return true
+}
+
+func (slot *activeRoomSlot) getSDKSessionID() string {
+	if slot == nil {
+		return ""
+	}
+	slot.stateMu.RLock()
+	defer slot.stateMu.RUnlock()
+	return strings.TrimSpace(slot.SDKSessionID)
+}
+
+func (slot *activeRoomSlot) setClient(client runtimectx.Client) {
+	if slot == nil {
+		return
+	}
+	slot.stateMu.Lock()
+	slot.Client = client
+	slot.stateMu.Unlock()
+}
+
+func (slot *activeRoomSlot) getClient() runtimectx.Client {
+	if slot == nil {
+		return nil
+	}
+	slot.stateMu.RLock()
+	defer slot.stateMu.RUnlock()
+	return slot.Client
+}
+
+func (slot *activeRoomSlot) setInterruptReason(reason string) {
+	if slot == nil {
+		return
+	}
+	slot.stateMu.Lock()
+	slot.InterruptReason = reason
+	slot.stateMu.Unlock()
+}
+
+func (slot *activeRoomSlot) getInterruptReason() string {
+	if slot == nil {
+		return ""
+	}
+	slot.stateMu.RLock()
+	defer slot.stateMu.RUnlock()
+	return strings.TrimSpace(slot.InterruptReason)
+}
+
+func (slot *activeRoomSlot) beginNoReplyCandidate() {
+	if slot == nil {
+		return
+	}
+	slot.stateMu.Lock()
+	slot.NoReplyCandidate = true
+	slot.stateMu.Unlock()
+}
+
+func (slot *activeRoomSlot) suppressOutput() {
+	if slot == nil {
+		return
+	}
+	slot.stateMu.Lock()
+	slot.SuppressOutput = true
+	slot.stateMu.Unlock()
+}
+
+func (slot *activeRoomSlot) shouldSuppressOutput() bool {
+	if slot == nil {
+		return false
+	}
+	slot.stateMu.RLock()
+	defer slot.stateMu.RUnlock()
+	return slot.SuppressOutput
+}
+
+func (slot *activeRoomSlot) eventsReadyForEmission(event protocol.EventMessage) []protocol.EventMessage {
+	if slot == nil {
+		return []protocol.EventMessage{event}
+	}
+	slot.stateMu.Lock()
+	defer slot.stateMu.Unlock()
+	if slot.SuppressOutput {
+		slot.PendingStream = nil
+		return nil
+	}
+	if slot.NoReplyCandidate {
+		if event.EventType != protocol.EventTypeStream {
+			slot.NoReplyCandidate = false
+		} else if roomdomain.IsNoReplyCandidateStreamEvent(event) {
+			slot.PendingStream = append(slot.PendingStream, event)
+			return nil
+		} else {
+			slot.NoReplyCandidate = false
+		}
+	}
+	if len(slot.PendingStream) == 0 {
+		return []protocol.EventMessage{event}
+	}
+	events := append([]protocol.EventMessage(nil), slot.PendingStream...)
+	slot.PendingStream = nil
+	events = append(events, event)
+	return events
+}
+
+func (slot *activeRoomSlot) markCancelled() bool {
+	if slot == nil {
+		return false
+	}
+	slot.stateMu.Lock()
+	defer slot.stateMu.Unlock()
+	if slot.Status == "cancelled" {
+		return false
+	}
+	slot.Status = "cancelled"
+	return true
+}
+
 func (slot *activeRoomSlot) enqueueQueuedInput(roundID string, content string) {
 	if slot == nil || strings.TrimSpace(content) == "" {
 		return
@@ -279,14 +435,14 @@ func markRoomSlotInterrupted(slot *activeRoomSlot, reason string) {
 	if slot == nil {
 		return
 	}
-	slot.InterruptReason = normalizeRoomInterruptReason(reason)
+	slot.setInterruptReason(normalizeRoomInterruptReason(reason))
 }
 
 func roomSlotInterruptReason(slot *activeRoomSlot) string {
 	if slot == nil {
 		return ""
 	}
-	return strings.TrimSpace(slot.InterruptReason)
+	return slot.getInterruptReason()
 }
 
 func (r *activeRoomRound) allSlotsCancelled() bool {
@@ -294,7 +450,7 @@ func (r *activeRoomRound) allSlotsCancelled() bool {
 		return false
 	}
 	for _, slot := range r.Slots {
-		if slot.Status != "cancelled" {
+		if slot == nil || slot.getStatus() != "cancelled" {
 			return false
 		}
 	}
@@ -306,7 +462,7 @@ func (r *activeRoomRound) hasSlotError() bool {
 		return false
 	}
 	for _, slot := range r.Slots {
-		if slot != nil && slot.Status == "error" {
+		if slot != nil && slot.getStatus() == "error" {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Guard Room realtime slot runtime state behind synchronized accessors so queue scheduling, interrupt handling, no-reply buffering, and execution result handling stop racing on shared slot fields.

## Changes

- add a slot-level RWMutex plus accessors for status, SDK session id, client handle, interrupt reason, and no-reply stream buffering
- switch queue lookup / interrupt / execution paths to use synchronized slot state access instead of bare field reads and writes
- centralize no-reply stream gating through the slot accessor path so buffered event emission shares the same lock discipline

## Testing

- go test ./internal/service/room -count=1
- go test -race ./internal/service/room -run 'TestRealtimeServiceQueuesPublicMentionWhenTargetRunning|TestRealtimeServiceDispatchesRoomUserQueueForIdleTargetWhileAnotherAgentRuns' -count=3
- go test ./...

Fixes #95