### PR TITLE
fix: #99 internal/runtime: summarizeStreamMessage regression breaks 4 tests

### DIFF
--- a/internal/runtime/debug_message.go
+++ b/internal/runtime/debug_message.go
@@ -231,7 +231,7 @@ func summarizeStreamMessage(message sdkprotocol.ReceivedMessage) string {
 		delta := rawMap(event["delta"])
 		deltaType := strings.TrimSpace(rawString(delta["type"]))
 		if deltaType != "" {
-			return fmt.Sprintf("stream")
+			return fmt.Sprintf("stream %s(%s)", eventType, deltaType)
 		}
 	case "content_block_start":
 		block := rawMap(event["content_block"])
@@ -240,7 +240,7 @@ func summarizeStreamMessage(message sdkprotocol.ReceivedMessage) string {
 			if blockType == "tool_use" {
 				preview = safeToolName(rawString(block["name"]))
 			}
-			return appendSummaryPreview(fmt.Sprintf("stream"), preview)
+			return appendSummaryPreview(fmt.Sprintf("stream %s", blockType), preview)
 		}
 	}
 	return appendSummaryPreview("stream "+eventType, preview)


### PR DESCRIPTION
## Summary

Restore the stream summary formatting in `summarizeStreamMessage` so debug logs and idle-timeout diagnostics keep the event subtype context that issue #99 expects.

## Changes

- restore `content_block_delta` summaries to include both event type and delta type
- restore `content_block_start` summaries to include block type
- keep tool-use summaries redacted to tool name only

## Testing

- `go test ./internal/runtime -run 'TestBuildSDKMessageLogSummary|TestExecuteRoundReturnsIdleTimeoutDiagnostics' -count=1`
- `go test ./internal/runtime -count=1`

Fixes nexus-research-lab/nexus#99