### PR TITLE
fix: #109 session 的标题生成后前端界面没有自动刷新

### DIFF
--- a/web/src/hooks/agent/use-agent-conversation.ts
+++ b/web/src/hooks/agent/use-agent-conversation.ts
@@ -1358,6 +1358,7 @@ export function useAgentConversation(
             latest_session_seq,
           );
         }
+        on_room_event_callback?.(event.event_type, event.data ?? {});
         void reload_current_session().finally(() => {
           if (!session_key || ws_state_ref.current !== "connected") {
             return;


### PR DESCRIPTION
## Summary

When the backend auto-generates a session title, the room page updated the bound session state but did not forward the `session_resync_required` event to the room-level refresh handler. As a result, the conversation list/card title stayed stale until a manual page refresh.

## Changes

- forward `session_resync_required` events to `on_room_event_callback` in `useAgentConversation`
- keep the existing session reload + websocket rebind behavior unchanged
- reuse the room page's existing refresh path for title updates

## Testing

- `cd web && pnpm lint`
- `cd web && pnpm typecheck`

Fixes #109