### PR TITLE
fix: 消除启动 panic 并收紧 WebSocket Origin 白名单

### DIFF
--- a/env.example
+++ b/env.example
@@ -42,6 +42,12 @@ DISCORD_BOT_TOKEN=
 TELEGRAM_ENABLED=true
 TELEGRAM_BOT_TOKEN=
 
+# WebSocket Origin Configuration
+# 限制 WebSocket 握手允许的 Origin 列表，多个值用逗号分隔。
+# 支持通配符模式，例如 "localhost:*", "app://*", "nexus://*"。
+# 留空时允许所有来源（向后兼容，不推荐生产环境使用）。
+ALLOWED_WEBSOCKET_ORIGINS=
+
 # Connector OAuth Configuration
 # 必须与各 provider 开发者后台登记的回调 URI 完全一致。
 CONNECTOR_OAUTH_REDIRECT_URI=http://localhost:3000/capability/connectors/oauth/callback

--- a/internal/app/server/internal_control.go
+++ b/internal/app/server/internal_control.go
@@ -9,12 +9,12 @@ import (
 	"github.com/nexus-research-lab/nexus/internal/config"
 )
 
-func newInternalControlToken() string {
+func newInternalControlToken() (string, error) {
 	buffer := make([]byte, 32)
 	if _, err := rand.Read(buffer); err != nil {
-		panic(fmt.Errorf("生成内部控制面 token 失败: %w", err))
+		return "", fmt.Errorf("生成内部控制面 token 失败: %w", err)
 	}
-	return hex.EncodeToString(buffer)
+	return hex.EncodeToString(buffer), nil
 }
 
 func internalControlBaseURL(cfg config.Config) string {

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -38,8 +38,11 @@ func NewWithLogger(cfg config.Config, logger *slog.Logger) (*Server, error) {
 	}
 
 	api := handlershared.NewAPI(logger)
-	websocketHandler := newWebSocketHandler(api, appServices)
-	internalControlToken := newInternalControlToken()
+	websocketHandler := newWebSocketHandler(api, appServices, cfg)
+	internalControlToken, err := newInternalControlToken()
+	if err != nil {
+		return nil, err
+	}
 	if appServices.RoomRealtime != nil {
 		appServices.RoomRealtime.SetInternalAPI(internalControlBaseURL(cfg), internalControlToken)
 	}

--- a/internal/app/server/websocket.go
+++ b/internal/app/server/websocket.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/nexus-research-lab/nexus/internal/config"
 	handlershared "github.com/nexus-research-lab/nexus/internal/handler/shared"
 	handlerwebsocket "github.com/nexus-research-lab/nexus/internal/handler/websocket"
 )
@@ -8,6 +9,7 @@ import (
 func newWebSocketHandler(
 	api *handlershared.API,
 	services *AppServices,
+	cfg config.Config,
 ) *handlerwebsocket.Handler {
 	return handlerwebsocket.NewHandler(
 		api,
@@ -19,6 +21,7 @@ func newWebSocketHandler(
 		services.Channels,
 		services.Workspace,
 		newRuntimeSnapshotProvider(services),
+		cfg.AllowedWebSocketOrigins,
 	)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	TelegramBotToken               string
 	ConnectorOAuthRedirectURI      string
 	ConnectorOAuthAllowedOrigins   []string
+	AllowedWebSocketOrigins        []string
 	ConnectorOAuthStateTTLSeconds  int
 	ConnectorCredentialsKey        string
 	ConnectorGitHubClientID        string
@@ -148,6 +149,7 @@ func Load() Config {
 		TelegramBotToken:               getEnv("TELEGRAM_BOT_TOKEN", ""),
 		ConnectorOAuthRedirectURI:      getEnv("CONNECTOR_OAUTH_REDIRECT_URI", "http://localhost:3000/capability/connectors/oauth/callback"),
 		ConnectorOAuthAllowedOrigins:   mustStringList(getEnv("CONNECTOR_OAUTH_ALLOWED_ORIGINS", "http://localhost:3000")),
+		AllowedWebSocketOrigins:        mustStringList(getEnv("ALLOWED_WEBSOCKET_ORIGINS", "")),
 		ConnectorOAuthStateTTLSeconds:  mustInt(getEnv("CONNECTOR_OAUTH_STATE_TTL_SECONDS", "600")),
 		ConnectorCredentialsKey:        getEnv("CONNECTOR_CREDENTIALS_KEY", ""),
 		ConnectorGitHubClientID:        getEnv("CONNECTOR_GITHUB_CLIENT_ID", ""),

--- a/internal/handler/websocket/handler.go
+++ b/internal/handler/websocket/handler.go
@@ -37,6 +37,7 @@ type Handler struct {
 	channels      *channelspkg.Router
 	roomSubs      *roomSubscriptionRegistry
 	workspaceSubs *workspaceSubscriptionRegistry
+	allowedOrigins []string
 }
 
 // NewHandler 创建 WebSocket handler。
@@ -50,6 +51,7 @@ func NewHandler(
 	channels *channelspkg.Router,
 	workspaceService *workspacepkg.Service,
 	runtimeProvider func(string) RuntimeSnapshot,
+	allowedOrigins []string,
 ) *Handler {
 	handler := &Handler{
 		api:           api,
@@ -61,6 +63,7 @@ func NewHandler(
 		channels:      channels,
 		roomSubs:      newRoomSubscriptionRegistry(128),
 		workspaceSubs: newWorkspaceSubscriptionRegistry(workspaceService, runtimeProvider),
+		allowedOrigins: allowedOrigins,
 	}
 	if roomRealtime != nil {
 		roomRealtime.SetRoomBroadcaster(handler.roomSubs)
@@ -70,8 +73,14 @@ func NewHandler(
 
 // HandleWebSocket 处理 WebSocket 会话。
 func (h *Handler) HandleWebSocket(writer http.ResponseWriter, request *http.Request) {
+	originPatterns := h.allowedOrigins
+	if len(originPatterns) == 0 {
+		// 未配置白名单时保持向后兼容，允许所有来源。
+		// 部署环境建议通过 ALLOWED_WEBSOCKET_ORIGINS 显式指定允许的 Origin。
+		originPatterns = []string{"*"}
+	}
 	connection, err := websocket.Accept(writer, request, &websocket.AcceptOptions{
-		OriginPatterns: []string{"*"},
+		OriginPatterns: originPatterns,
 		Subprotocols:   []string{handlershared.DesktopWebSocketSubprotocol},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- **修复 #110**：将 `newInternalControlToken()` 从 `panic` 改为返回 `(string, error)`，启动路径在 `crypto/rand.Read` 失败时优雅返回错误，不再进程崩溃
- **修复 #111**：新增 `ALLOWED_WEBSOCKET_ORIGINS` 环境变量，支持 WebSocket Origin 白名单配置，替代硬编码的 `OriginPatterns: ["*"]`

## 变更详情

### #110 — crypto/rand.Read panic 消除
- `internal/app/server/internal_control.go`: `newInternalControlToken()` 返回 `(string, error)` 而非 `panic`
- `internal/app/server/server.go`: 调用方处理错误并向上传播

### #111 — WebSocket Origin 白名单
- `internal/config/config.go`: 新增 `AllowedWebSocketOrigins` 配置字段
- `internal/handler/websocket/handler.go`: Handler 持有 `allowedOrigins`，`HandleWebSocket` 使用白名单
- `internal/app/server/websocket.go`: 传递 config 到 WebSocket handler
- `env.example`: 添加 `ALLOWED_WEBSOCKET_ORIGINS` 说明

**向后兼容**：未配置 `ALLOWED_WEBSOCKET_ORIGINS` 时行为不变（允许所有来源），生产环境建议显式配置。

## Test plan
- [x] `go build ./...` 编译通过
- [x] `go test ./internal/app/server/... ./internal/handler/websocket/...` 全部通过
- [x] 默认配置（空白名单）行为与改动前一致
- [ ] 部署环境配置 `ALLOWED_WEBSOCKET_ORIGINS=localhost:*,127.0.0.1:*` 验证 Origin 拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)