### PR TITLE
fix: 消除 PostCSS XSS 漏洞 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -54,5 +54,10 @@
     "typescript": "^5",
     "typescript-eslint": "^8.46.1",
     "vite": "npm:rolldown-vite@latest"
+  },
+  "pnpm": {
+    "overrides": {
+      "postcss": ">=8.5.10"
+    }
   }
 }


### PR DESCRIPTION
## Summary

通过 `pnpm.overrides` 强制 `postcss >= 8.5.10`，修复 `pnpm audit` 报告的 XSS 漏洞 (GHSA-qx2v-qp2m-jg93)。

## Changes

- `web/package.json`: 新增 `pnpm.overrides` 字段，强制所有间接依赖使用 `postcss >= 8.5.10`

## 背景

当前依赖树中 `postcss@8.5.6` 通过 `@tailwindcss/postcss` 和 `rolldown-vite` 间接引入，低于修复版本 `8.5.10`。该版本存在 CSS stringify 输出中未转义 `<style>` 标签的 XSS 风险。

## Test plan

- [ ] `cd web && pnpm install` 更新 lockfile
- [ ] `cd web && pnpm audit` 确认漏洞消失
- [ ] `cd web && pnpm run build` 确认构建正常
- [ ] `cd web && pnpm run typecheck` 确认类型检查通过

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)