### PR TITLE
fix: #116 Access token passed in query string is written verbatim to access logs

### DIFF
--- a/internal/handler/shared/middleware.go
+++ b/internal/handler/shared/middleware.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -140,7 +141,7 @@ func AccessLogMiddleware() func(http.Handler) http.Handler {
 				"remote_ip", ClientIP(request),
 				"path", request.URL.Path,
 			}
-			if rawQuery := strings.TrimSpace(request.URL.RawQuery); rawQuery != "" {
+			if rawQuery := sanitizeAccessLogQuery(request.URL.RawQuery); rawQuery != "" {
 				fields = append(fields, "query", rawQuery)
 			}
 
@@ -229,6 +230,23 @@ func AuthMiddleware(api *API, auth *authsvc.Service) func(http.Handler) http.Han
 			next.ServeHTTP(writer, request.WithContext(ctx))
 		})
 	}
+}
+
+func sanitizeAccessLogQuery(rawQuery string) string {
+	trimmed := strings.TrimSpace(rawQuery)
+	if trimmed == "" {
+		return ""
+	}
+	values, err := url.ParseQuery(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	for _, key := range []string{"access_token", "token"} {
+		if _, exists := values[key]; exists {
+			values.Set(key, "REDACTED")
+		}
+	}
+	return values.Encode()
 }
 
 func normalizeAPIPrefix(prefix string) string {

--- a/internal/handler/shared/middleware_test.go
+++ b/internal/handler/shared/middleware_test.go
@@ -76,6 +76,35 @@ func TestRecoverMiddlewareReturnsInternalError(t *testing.T) {
 	}
 }
 
+func TestAccessLogMiddlewareRedactsSensitiveQueryValues(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	handler := RequestContextMiddleware(logger)(
+		AccessLogMiddleware()(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+		})),
+	)
+
+	request := httptest.NewRequest(http.MethodGet, "/nexus/v1/agents?access_token=super-secret&token=another-secret&limit=10", nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	output := buffer.String()
+	if strings.Contains(output, "super-secret") || strings.Contains(output, "another-secret") {
+		t.Fatalf("access log 不应泄露敏感 query 参数: %s", output)
+	}
+	if !strings.Contains(output, "access_token=REDACTED") {
+		t.Fatalf("access log 未脱敏 access_token: %s", output)
+	}
+	if !strings.Contains(output, "token=REDACTED") {
+		t.Fatalf("access log 未脱敏 token: %s", output)
+	}
+	if !strings.Contains(output, "limit=10") {
+		t.Fatalf("access log 不应移除非敏感 query 参数: %s", output)
+	}
+}
+
 func TestDesktopSessionTokenMiddlewareProtectsAPI(t *testing.T) {
 	api := NewAPI(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	handler := DesktopSessionTokenMiddleware(api, "desktop-token", "/nexus/v1")(


### PR DESCRIPTION
## Summary
- redact access_token and token query values before writing access logs
- keep non-sensitive query parameters visible for debugging
- add regression coverage to prevent secret leakage in logs

## Testing
- go test ./internal/handler/shared ./internal/service/auth
- go test ./... *(currently has an unrelated existing failure in internal/service/room: TestRoomServiceProjectsAgentPrivateDomain)*

Fixes #116