### PR TITLE
fix: repair legacy SQLite migration startup

### DIFF
--- a/cmd/nexus-server/main.go
+++ b/cmd/nexus-server/main.go
@@ -39,6 +39,13 @@ func runMigrations(cfg config.Config, logger *slog.Logger) error {
 	}
 
 	logger.Info("执行数据库迁移", "current_version", version, "dir", dir)
+	version, err = reconcileLegacySQLiteMigrationVersion(db, cfg.DatabaseDriver, version, logger)
+	if err != nil {
+		return err
+	}
+	if version > 0 {
+		logger.Info("数据库迁移版本就绪", "current_version", version)
+	}
 	if err = goose.Up(db, dir); err != nil {
 		return fmt.Errorf("run goose up: %w", err)
 	}

--- a/cmd/nexus-server/migration_reconcile.go
+++ b/cmd/nexus-server/migration_reconcile.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/nexus-research-lab/nexus/internal/storage"
+)
+
+const sqliteLegacyVersionTable = "goose_db_version"
+
+var sqliteMigrationVersions = []int64{
+	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+	28, 29, 30, 31, 32, 33, 34, 35, 36,
+}
+
+var sqliteInitialMigrationTables = []string{
+	"agents",
+	"automation_system_events",
+	"auth_sessions",
+	"rooms",
+	"connector_connections",
+	"automation_cron_jobs",
+	"automation_delivery_routes",
+	"automation_heartbeat_states",
+	"contacts",
+	"conversations",
+	"members",
+	"profiles",
+	"runtimes",
+	"provider",
+	"automation_cron_runs",
+	"sessions",
+	"messages",
+	"rounds",
+}
+
+type sqliteSchemaMarker struct {
+	version int64
+	tables  []string
+	columns map[string][]string
+	indexes []string
+}
+
+var sqliteLegacySchemaMarkers = []sqliteSchemaMarker{
+	{version: 2, tables: []string{"users", "auth_password_credentials"}, columns: map[string][]string{"auth_sessions": {"session_id", "user_id", "auth_method"}}},
+	{version: 3, columns: map[string][]string{"agents": {"owner_user_id", "is_main"}, "rooms": {"owner_user_id"}}},
+	{version: 5, tables: []string{"connector_oauth_states"}},
+	{version: 6, columns: map[string][]string{"connector_connections": {"credentials_encrypted"}}},
+	{version: 7, tables: []string{"connector_oauth_clients"}},
+	{version: 8, tables: []string{"token_usage_records"}},
+	{version: 9, columns: map[string][]string{"users": {"avatar"}}},
+	{version: 10, indexes: []string{"idx_rooms_owner_updated", "idx_agents_owner_status_main_created"}},
+	{version: 11, columns: map[string][]string{"automation_cron_jobs": {"owner_user_id", "overlap_policy"}, "automation_cron_runs": {"owner_user_id", "trigger_kind", "result_summary"}}},
+	{version: 12, tables: []string{"im_channel_configs", "im_pairings"}},
+	{version: 13, columns: map[string][]string{"rooms": {"skill_names"}}},
+	{version: 14, columns: map[string][]string{"provider": {"provider_kind"}}},
+	{version: 15, columns: map[string][]string{"connector_oauth_states": {"redirect_kind"}}},
+	{version: 16, columns: map[string][]string{"rooms": {"host_agent_id", "host_auto_reply_enabled"}}},
+	{version: 28, columns: map[string][]string{"automation_cron_jobs": {"next_run_at", "running_run_id", "last_delivery_status"}}},
+	{version: 29, columns: map[string][]string{"automation_cron_runs": {"assistant_text", "result_text", "artifact_path"}}},
+	{version: 30, columns: map[string][]string{"automation_cron_jobs": {"execution_kind"}}},
+	{version: 31, columns: map[string][]string{"automation_cron_runs": {"delivery_status"}}},
+	{version: 32, columns: map[string][]string{"automation_cron_runs": {"delivery_error", "delivered_at", "delivery_attempts"}}},
+	{version: 33, columns: map[string][]string{"automation_cron_runs": {"delivery_next_attempt_at", "delivery_dead_letter_at"}}},
+	{version: 34, tables: []string{"im_ingress_messages"}},
+	{version: 35, tables: []string{"automation_task_events"}},
+}
+
+func reconcileLegacySQLiteMigrationVersion(db *sql.DB, driver string, currentVersion int64, logger *slog.Logger) (int64, error) {
+	if currentVersion != 0 || !storage.IsSQLiteSQLDriver(storage.NormalizeSQLDriver(driver)) {
+		return currentVersion, nil
+	}
+
+	initialPresent, missingInitial, err := sqliteRequiredTablesStatus(db, sqliteInitialMigrationTables)
+	if err != nil {
+		return currentVersion, fmt.Errorf("inspect sqlite legacy schema: %w", err)
+	}
+	if initialPresent == 0 {
+		return currentVersion, nil
+	}
+	if len(missingInitial) > 0 {
+		return currentVersion, fmt.Errorf("sqlite legacy schema is partial while goose version is 0; missing initial tables: %s", strings.Join(missingInitial, ", "))
+	}
+
+	repairedVersion, err := detectSQLiteLegacySchemaVersion(db)
+	if err != nil {
+		return currentVersion, err
+	}
+	if repairedVersion == 0 {
+		return currentVersion, nil
+	}
+
+	if err = markSQLiteMigrationVersionsApplied(db, repairedVersion); err != nil {
+		return currentVersion, err
+	}
+	logger.Info("已修复 SQLite legacy migration 版本", "detected_version", repairedVersion)
+	return repairedVersion, nil
+}
+
+func detectSQLiteLegacySchemaVersion(db *sql.DB) (int64, error) {
+	version := int64(1)
+	for _, marker := range sqliteLegacySchemaMarkers {
+		matched, err := sqliteSchemaMarkerMatches(db, marker)
+		if err != nil {
+			return 0, fmt.Errorf("inspect sqlite migration marker %d: %w", marker.version, err)
+		}
+		if matched && marker.version > version {
+			version = marker.version
+		}
+	}
+	return version, nil
+}
+
+func sqliteSchemaMarkerMatches(db *sql.DB, marker sqliteSchemaMarker) (bool, error) {
+	for _, table := range marker.tables {
+		exists, err := sqliteTableExists(db, table)
+		if err != nil || !exists {
+			return false, err
+		}
+	}
+	for table, columns := range marker.columns {
+		for _, column := range columns {
+			exists, err := sqliteColumnExists(db, table, column)
+			if err != nil || !exists {
+				return false, err
+			}
+		}
+	}
+	for _, index := range marker.indexes {
+		exists, err := sqliteIndexExists(db, index)
+		if err != nil || !exists {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func sqliteRequiredTablesStatus(db *sql.DB, tables []string) (int, []string, error) {
+	present := 0
+	var missing []string
+	for _, table := range tables {
+		exists, err := sqliteTableExists(db, table)
+		if err != nil {
+			return 0, nil, err
+		}
+		if exists {
+			present++
+		} else {
+			missing = append(missing, table)
+		}
+	}
+	return present, missing, nil
+}
+
+func sqliteTableExists(db *sql.DB, table string) (bool, error) {
+	return sqliteObjectExists(db, "table", table)
+}
+
+func sqliteIndexExists(db *sql.DB, index string) (bool, error) {
+	return sqliteObjectExists(db, "index", index)
+}
+
+func sqliteObjectExists(db *sql.DB, objectType string, name string) (bool, error) {
+	var count int
+	err := db.QueryRow(
+		"SELECT COUNT(1) FROM sqlite_master WHERE type = ? AND name = ?",
+		objectType,
+		name,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func sqliteColumnExists(db *sql.DB, table string, column string) (bool, error) {
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name string
+		var columnType string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err = rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func markSQLiteMigrationVersionsApplied(db *sql.DB, version int64) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for _, migrationVersion := range sqliteMigrationVersions {
+		if migrationVersion > version {
+			break
+		}
+		if _, err = tx.Exec(
+			"INSERT INTO "+sqliteLegacyVersionTable+" (version_id, is_applied) VALUES (?, ?)",
+			migrationVersion,
+			true,
+		); err != nil {
+			return fmt.Errorf("mark sqlite migration %d applied: %w", migrationVersion, err)
+		}
+	}
+	return tx.Commit()
+}

--- a/cmd/nexus-server/migration_reconcile_test.go
+++ b/cmd/nexus-server/migration_reconcile_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"database/sql"
+	"io"
+	"log/slog"
+	"math"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/nexus-research-lab/nexus/internal/config"
+
+	"github.com/pressly/goose/v3"
+	_ "modernc.org/sqlite"
+)
+
+func TestRunMigrationsRepairsLegacySQLiteVersionZero(t *testing.T) {
+	t.Chdir(projectRootForMigrationTest(t))
+
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("打开测试数据库失败: %v", err)
+	}
+	if err = goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("设置 goose dialect 失败: %v", err)
+	}
+	if err = goose.UpTo(db, filepath.Join("db", "migrations", "sqlite"), 2); err != nil {
+		t.Fatalf("准备 legacy schema 失败: %v", err)
+	}
+	if _, err = db.Exec("DELETE FROM goose_db_version"); err != nil {
+		t.Fatalf("清理 goose version 失败: %v", err)
+	}
+	if _, err = db.Exec("INSERT INTO goose_db_version (version_id, is_applied) VALUES (0, 1)"); err != nil {
+		t.Fatalf("写入 legacy goose version 失败: %v", err)
+	}
+	if err = db.Close(); err != nil {
+		t.Fatalf("关闭准备数据库失败: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := config.Config{DatabaseDriver: "sqlite", DatabaseURL: dbPath}
+	if err = runMigrations(cfg, logger); err != nil {
+		t.Fatalf("legacy schema 迁移失败: %v", err)
+	}
+
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("重新打开测试数据库失败: %v", err)
+	}
+	defer db.Close()
+	version, err := goose.GetDBVersion(db)
+	if err != nil {
+		t.Fatalf("读取 goose version 失败: %v", err)
+	}
+	wantVersion := latestSQLiteMigrationVersion(t)
+	if version != wantVersion {
+		t.Fatalf("goose version = %d, want %d", version, wantVersion)
+	}
+	if !migrationTestColumnExists(t, db, "rooms", "skill_names") {
+		t.Fatal("后续迁移未继续执行: rooms.skill_names 不存在")
+	}
+}
+
+func projectRootForMigrationTest(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("无法定位测试文件")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..")
+}
+
+func latestSQLiteMigrationVersion(t *testing.T) int64 {
+	t.Helper()
+
+	migrations, err := goose.CollectMigrations(filepath.Join("db", "migrations", "sqlite"), 0, math.MaxInt64)
+	if err != nil {
+		t.Fatalf("读取 SQLite migration 文件失败: %v", err)
+	}
+	if len(migrations) == 0 {
+		t.Fatal("未读取到 SQLite migration 文件")
+	}
+	return migrations[len(migrations)-1].Version
+}
+
+func migrationTestColumnExists(t *testing.T, db *sql.DB, table string, column string) bool {
+	t.Helper()
+
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatalf("读取表结构失败: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name string
+		var columnType string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err = rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			t.Fatalf("扫描表结构失败: %v", err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	if err = rows.Err(); err != nil {
+		t.Fatalf("遍历表结构失败: %v", err)
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- repair SQLite startup migration when an existing schema has goose version 0
- detect the already-applied legacy schema baseline before running goose.Up
- add a regression test for the desktop startup failure in #120

## Issue status
- Fixes #120
- #123 is already resolved on current main; verified room skill catalog returns room-playbook and werewolf-6p

## Validation
- go test ./cmd/nexus-server -run TestRunMigrationsRepairsLegacySQLiteVersionZero -count=1
- go test ./internal/service/skills -run TestServiceImportsAndInstallsSkill -count=1
- GET /nexus/v1/skills?scope=room returns room-playbook and werewolf-6p
- make check