### PR TITLE
fix: #126 connector connections are not scoped by owner_user_id, allowing cross-user token reuse

### DIFF
--- a/db/migrations/postgres/00018_connector_connections_owner_scope.sql
+++ b/db/migrations/postgres/00018_connector_connections_owner_scope.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+ALTER TABLE connector_connections ADD COLUMN IF NOT EXISTS owner_user_id VARCHAR(64) NOT NULL DEFAULT '__system__';
+
+ALTER TABLE connector_connections DROP CONSTRAINT IF EXISTS connector_connections_pkey;
+ALTER TABLE connector_connections ADD PRIMARY KEY (owner_user_id, connector_id);
+
+CREATE INDEX IF NOT EXISTS idx_connector_connections_owner_state ON connector_connections (owner_user_id, state);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_connector_connections_owner_state;
+
+ALTER TABLE connector_connections DROP CONSTRAINT IF EXISTS connector_connections_pkey;
+ALTER TABLE connector_connections ADD PRIMARY KEY (connector_id);
+ALTER TABLE connector_connections DROP COLUMN IF EXISTS owner_user_id;

--- a/db/migrations/sqlite/00018_connector_connections_owner_scope.sql
+++ b/db/migrations/sqlite/00018_connector_connections_owner_scope.sql
@@ -1,0 +1,72 @@
+-- +goose Up
+PRAGMA foreign_keys = OFF;
+
+DROP INDEX IF EXISTS idx_connector_connections_state;
+
+ALTER TABLE connector_connections RENAME TO connector_connections_old;
+
+CREATE TABLE connector_connections (
+    owner_user_id VARCHAR(64) NOT NULL DEFAULT '__system__',
+    connector_id VARCHAR(128) NOT NULL,
+    state VARCHAR(32) NOT NULL,
+    credentials TEXT NOT NULL,
+    auth_type VARCHAR(32) NOT NULL,
+    oauth_state VARCHAR(255),
+    oauth_state_expires_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    credentials_encrypted TEXT,
+    PRIMARY KEY (owner_user_id, connector_id)
+);
+
+INSERT INTO connector_connections (
+    owner_user_id, connector_id, state, credentials, auth_type, oauth_state, oauth_state_expires_at,
+    created_at, updated_at, credentials_encrypted
+)
+SELECT
+    '__system__', connector_id, state, credentials, auth_type, oauth_state, oauth_state_expires_at,
+    created_at, updated_at, credentials_encrypted
+FROM connector_connections_old;
+
+DROP TABLE connector_connections_old;
+
+CREATE INDEX IF NOT EXISTS idx_connector_connections_state ON connector_connections (state);
+CREATE INDEX IF NOT EXISTS idx_connector_connections_owner_state ON connector_connections (owner_user_id, state);
+
+PRAGMA foreign_keys = ON;
+
+-- +goose Down
+PRAGMA foreign_keys = OFF;
+
+DROP INDEX IF EXISTS idx_connector_connections_owner_state;
+DROP INDEX IF EXISTS idx_connector_connections_state;
+
+ALTER TABLE connector_connections RENAME TO connector_connections_new;
+
+CREATE TABLE connector_connections (
+    connector_id VARCHAR(128) NOT NULL PRIMARY KEY,
+    state VARCHAR(32) NOT NULL,
+    credentials TEXT NOT NULL,
+    auth_type VARCHAR(32) NOT NULL,
+    oauth_state VARCHAR(255),
+    oauth_state_expires_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    credentials_encrypted TEXT
+);
+
+INSERT INTO connector_connections (
+    connector_id, state, credentials, auth_type, oauth_state, oauth_state_expires_at,
+    created_at, updated_at, credentials_encrypted
+)
+SELECT
+    connector_id, state, credentials, auth_type, oauth_state, oauth_state_expires_at,
+    created_at, updated_at, credentials_encrypted
+FROM connector_connections_new
+WHERE owner_user_id = '__system__';
+
+DROP TABLE connector_connections_new;
+
+CREATE INDEX IF NOT EXISTS idx_connector_connections_state ON connector_connections (state);
+
+PRAGMA foreign_keys = ON;

--- a/internal/handler/capability/handlers.go
+++ b/internal/handler/capability/handlers.go
@@ -55,7 +55,7 @@ func (h *Handlers) HandleCapabilitySummary(writer http.ResponseWriter, request *
 		return
 	}
 
-	connectorCount, err := h.connectors.GetConnectedCount(request.Context())
+	connectorCount, err := h.connectors.GetConnectedCount(request.Context(), authsvc.OwnerUserID(request.Context()))
 	if err != nil {
 		h.api.WriteFailure(writer, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/handler/connector/handlers.go
+++ b/internal/handler/connector/handlers.go
@@ -50,7 +50,7 @@ func (h *Handlers) HandleConnectorCategories(writer http.ResponseWriter, request
 }
 
 func (h *Handlers) HandleConnectorCount(writer http.ResponseWriter, request *http.Request) {
-	count, err := h.connectors.GetConnectedCount(request.Context())
+	count, err := h.connectors.GetConnectedCount(request.Context(), currentOwnerUserID(request))
 	if err != nil {
 		h.api.WriteFailure(writer, http.StatusInternalServerError, err.Error())
 		return
@@ -177,7 +177,7 @@ func (h *Handlers) HandleConnectConnector(writer http.ResponseWriter, request *h
 	if !h.api.BindJSONAllowEmpty(writer, request, &payload) {
 		return
 	}
-	item, err := h.connectors.Connect(request.Context(), chi.URLParam(request, "connector_id"), payload)
+	item, err := h.connectors.Connect(request.Context(), currentOwnerUserID(request), chi.URLParam(request, "connector_id"), payload)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "未知连接器") {
 			h.api.WriteFailure(writer, http.StatusNotFound, "资源不存在")

--- a/internal/service/connectors/service.go
+++ b/internal/service/connectors/service.go
@@ -16,6 +16,7 @@ import (
 	connectordomain "github.com/nexus-research-lab/nexus/internal/connectors"
 	"github.com/nexus-research-lab/nexus/internal/connectors/credentials"
 	"github.com/nexus-research-lab/nexus/internal/connectors/providers"
+	authctx "github.com/nexus-research-lab/nexus/internal/infra/authctx"
 	"github.com/nexus-research-lab/nexus/internal/storage"
 	connectorstore "github.com/nexus-research-lab/nexus/internal/storage/connectors"
 )
@@ -107,6 +108,7 @@ const (
 )
 
 type connectionRecord struct {
+	OwnerUserID          string
 	ConnectorID          string
 	State                string
 	Credentials          string
@@ -150,7 +152,7 @@ func NewService(cfg config.Config, db *sql.DB) *Service {
 
 // ListConnectors 列出连接器目录。
 func (s *Service) ListConnectors(ctx context.Context, ownerUserID string, query string, category string, status string) ([]Info, error) {
-	states, err := s.listConnectionStates(ctx)
+	states, err := s.listConnectionStates(ctx, ownerUserID)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +180,7 @@ func (s *Service) GetConnectorDetail(ctx context.Context, ownerUserID string, co
 	if !ok {
 		return nil, errors.New("connector not found")
 	}
-	state, err := s.connectionState(ctx, entry.ConnectorID)
+	state, err := s.connectionState(ctx, ownerUserID, entry.ConnectorID)
 	if err != nil {
 		return nil, err
 	}
@@ -186,11 +188,11 @@ func (s *Service) GetConnectorDetail(ctx context.Context, ownerUserID string, co
 	return &detail, nil
 }
 
-// GetConnectedCount 返回已连接数量。
-func (s *Service) GetConnectedCount(ctx context.Context) (int, error) {
-	query := "SELECT COUNT(1) FROM connector_connections WHERE state = 'connected'"
+// GetConnectedCount 返回当前 owner 的已连接数量。
+func (s *Service) GetConnectedCount(ctx context.Context, ownerUserID string) (int, error) {
+	query := fmt.Sprintf("SELECT COUNT(1) FROM connector_connections WHERE owner_user_id = %s AND state = 'connected'", s.bind(1))
 	var count int
-	if err := s.db.QueryRowContext(ctx, query).Scan(&count); err != nil {
+	if err := s.db.QueryRowContext(ctx, query, effectiveOwnerUserID(ownerUserID)).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil
@@ -235,7 +237,7 @@ func (s *Service) SaveOAuthClientConfig(ctx context.Context, ownerUserID string,
 	}); err != nil {
 		return nil, err
 	}
-	state, err := s.connectionState(ctx, entry.ConnectorID)
+	state, err := s.connectionState(ctx, ownerUserID, entry.ConnectorID)
 	if err != nil {
 		return nil, err
 	}
@@ -264,6 +266,7 @@ func (s *Service) DeleteOAuthClientConfig(ctx context.Context, ownerUserID strin
 		return nil, err
 	}
 	if err = s.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: ownerUserID,
 		ConnectorID: entry.ConnectorID,
 		State:       "disconnected",
 		Credentials: "",
@@ -275,9 +278,10 @@ func (s *Service) DeleteOAuthClientConfig(ctx context.Context, ownerUserID strin
 	return &info, nil
 }
 
-// ListActiveConnections 列出已连接 connector，暂时保留 ownerUserID 签名供后续 user scope 使用。
+// ListActiveConnections 列出当前 owner 已连接的 connector。
 func (s *Service) ListActiveConnections(ctx context.Context, ownerUserID string) ([]connectordomain.ConnectionSnapshot, error) {
-	rows, err := s.db.QueryContext(ctx, "SELECT connector_id, credentials, credentials_encrypted, auth_type FROM connector_connections WHERE state = 'connected'")
+	query := fmt.Sprintf("SELECT owner_user_id, connector_id, credentials, credentials_encrypted, auth_type FROM connector_connections WHERE owner_user_id = %s AND state = 'connected'", s.bind(1))
+	rows, err := s.db.QueryContext(ctx, query, effectiveOwnerUserID(ownerUserID))
 	if err != nil {
 		return nil, err
 	}
@@ -286,6 +290,7 @@ func (s *Service) ListActiveConnections(ctx context.Context, ownerUserID string)
 	for rows.Next() {
 		var record connectionRecord
 		if err = rows.Scan(
+			&record.OwnerUserID,
 			&record.ConnectorID,
 			&record.Credentials,
 			&record.CredentialsEncrypted,
@@ -304,15 +309,16 @@ func (s *Service) ListActiveConnections(ctx context.Context, ownerUserID string)
 	return result, rows.Err()
 }
 
-// LoadActiveConnection 读取已连接 connector 的 token 快照。
+// LoadActiveConnection 读取当前 owner 已连接 connector 的 token 快照。
 func (s *Service) LoadActiveConnection(ctx context.Context, ownerUserID, connectorID string) (*connectordomain.ConnectionSnapshot, error) {
-	// TODO(connector-user-scope): 追加 owner_user_id 过滤 —— 见 Phase 3。
 	query := fmt.Sprintf(
-		"SELECT connector_id, credentials, credentials_encrypted, auth_type FROM connector_connections WHERE connector_id = %s AND state = 'connected'",
+		"SELECT owner_user_id, connector_id, credentials, credentials_encrypted, auth_type FROM connector_connections WHERE owner_user_id = %s AND connector_id = %s AND state = 'connected'",
 		s.bind(1),
+		s.bind(2),
 	)
 	var record connectionRecord
-	err := s.db.QueryRowContext(ctx, query, strings.TrimSpace(connectorID)).Scan(
+	err := s.db.QueryRowContext(ctx, query, effectiveOwnerUserID(ownerUserID), strings.TrimSpace(connectorID)).Scan(
+		&record.OwnerUserID,
 		&record.ConnectorID,
 		&record.Credentials,
 		&record.CredentialsEncrypted,
@@ -417,6 +423,7 @@ func (s *Service) refreshActiveConnectionIfNeeded(ctx context.Context, ownerUser
 	record.Credentials = string(encoded)
 	record.CredentialsEncrypted = sql.NullString{}
 	if err = s.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: ownerUserID,
 		ConnectorID: record.ConnectorID,
 		State:       "connected",
 		Credentials: record.Credentials,
@@ -592,6 +599,7 @@ func (s *Service) CompleteOAuthCallback(ctx context.Context, ownerUserID string,
 	}
 	credentials := mergeCredentialExtras(normalizeOAuthPayload(payload), extra)
 	if err = s.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: ownerUserID,
 		ConnectorID: entry.ConnectorID,
 		State:       "connected",
 		Credentials: credentials,
@@ -674,6 +682,7 @@ func (s *Service) PollDeviceAuth(ctx context.Context, ownerUserID string, connec
 	}
 	credentials := normalizeOAuthPayload(payload)
 	if err = s.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: ownerUserID,
 		ConnectorID: entry.ConnectorID,
 		State:       "connected",
 		Credentials: credentials,
@@ -689,7 +698,7 @@ func (s *Service) PollDeviceAuth(ctx context.Context, ownerUserID string, connec
 }
 
 // Connect 使用显式凭证直接连接。
-func (s *Service) Connect(ctx context.Context, connectorID string, credentials map[string]string) (*Info, error) {
+func (s *Service) Connect(ctx context.Context, ownerUserID string, connectorID string, credentials map[string]string) (*Info, error) {
 	entry, ok := getConnector(connectorID)
 	if !ok {
 		return nil, errors.New("未知连接器")
@@ -705,6 +714,7 @@ func (s *Service) Connect(ctx context.Context, connectorID string, credentials m
 		return nil, err
 	}
 	if err = s.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: ownerUserID,
 		ConnectorID: entry.ConnectorID,
 		State:       "connected",
 		Credentials: string(payload),
@@ -712,7 +722,7 @@ func (s *Service) Connect(ctx context.Context, connectorID string, credentials m
 	}); err != nil {
 		return nil, err
 	}
-	info := s.toInfo(ctx, "", entry, "connected")
+	info := s.toInfo(ctx, ownerUserID, entry, "connected")
 	return &info, nil
 }
 
@@ -723,6 +733,7 @@ func (s *Service) Disconnect(ctx context.Context, ownerUserID string, connectorI
 		return nil, errors.New("未知连接器")
 	}
 	if err := s.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: ownerUserID,
 		ConnectorID: entry.ConnectorID,
 		State:       "disconnected",
 		Credentials: "",
@@ -781,8 +792,9 @@ func (s *Service) toDetail(ctx context.Context, ownerUserID string, entry Catalo
 	}
 }
 
-func (s *Service) listConnectionStates(ctx context.Context) (map[string]string, error) {
-	rows, err := s.db.QueryContext(ctx, "SELECT connector_id, state FROM connector_connections")
+func (s *Service) listConnectionStates(ctx context.Context, ownerUserID string) (map[string]string, error) {
+	query := fmt.Sprintf("SELECT connector_id, state FROM connector_connections WHERE owner_user_id = %s", s.bind(1))
+	rows, err := s.db.QueryContext(ctx, query, effectiveOwnerUserID(ownerUserID))
 	if err != nil {
 		return nil, err
 	}
@@ -799,13 +811,14 @@ func (s *Service) listConnectionStates(ctx context.Context) (map[string]string, 
 	return result, rows.Err()
 }
 
-func (s *Service) connectionState(ctx context.Context, connectorID string) (string, error) {
+func (s *Service) connectionState(ctx context.Context, ownerUserID, connectorID string) (string, error) {
 	query := fmt.Sprintf(
-		"SELECT state FROM connector_connections WHERE connector_id = %s LIMIT 1",
+		"SELECT state FROM connector_connections WHERE owner_user_id = %s AND connector_id = %s LIMIT 1",
 		s.bind(1),
+		s.bind(2),
 	)
 	var state string
-	err := s.db.QueryRowContext(ctx, query, strings.TrimSpace(connectorID)).Scan(&state)
+	err := s.db.QueryRowContext(ctx, query, effectiveOwnerUserID(ownerUserID), strings.TrimSpace(connectorID)).Scan(&state)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
@@ -885,15 +898,16 @@ func (s *Service) purgeExpiredStates(ctx context.Context) error {
 }
 
 func (s *Service) upsertConnection(ctx context.Context, record connectionRecord) error {
+	record.OwnerUserID = effectiveOwnerUserID(record.OwnerUserID)
 	if err := s.encryptConnectionCredentials(&record); err != nil {
 		return err
 	}
 	if s.driver == "pgx" {
 		query := `
 INSERT INTO connector_connections (
-    connector_id, state, credentials, credentials_encrypted, auth_type, oauth_state, oauth_state_expires_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7)
-ON CONFLICT (connector_id) DO UPDATE SET
+    owner_user_id, connector_id, state, credentials, credentials_encrypted, auth_type, oauth_state, oauth_state_expires_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (owner_user_id, connector_id) DO UPDATE SET
     state = EXCLUDED.state,
     credentials = EXCLUDED.credentials,
     credentials_encrypted = EXCLUDED.credentials_encrypted,
@@ -904,6 +918,7 @@ ON CONFLICT (connector_id) DO UPDATE SET
 		_, err := s.db.ExecContext(
 			ctx,
 			query,
+			record.OwnerUserID,
 			record.ConnectorID,
 			record.State,
 			record.Credentials,
@@ -916,9 +931,9 @@ ON CONFLICT (connector_id) DO UPDATE SET
 	}
 	query := `
 INSERT INTO connector_connections (
-    connector_id, state, credentials, credentials_encrypted, auth_type, oauth_state, oauth_state_expires_at
-) VALUES (?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(connector_id) DO UPDATE SET
+    owner_user_id, connector_id, state, credentials, credentials_encrypted, auth_type, oauth_state, oauth_state_expires_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(owner_user_id, connector_id) DO UPDATE SET
     state = excluded.state,
     credentials = excluded.credentials,
     credentials_encrypted = excluded.credentials_encrypted,
@@ -929,6 +944,7 @@ ON CONFLICT(connector_id) DO UPDATE SET
 	_, err := s.db.ExecContext(
 		ctx,
 		query,
+		record.OwnerUserID,
 		record.ConnectorID,
 		record.State,
 		record.Credentials,
@@ -938,6 +954,14 @@ ON CONFLICT(connector_id) DO UPDATE SET
 		nil,
 	)
 	return err
+}
+
+func effectiveOwnerUserID(ownerUserID string) string {
+	ownerUserID = strings.TrimSpace(ownerUserID)
+	if ownerUserID == "" {
+		return authctx.SystemUserID
+	}
+	return ownerUserID
 }
 
 func (s *Service) bind(index int) string {

--- a/internal/service/connectors/service_test.go
+++ b/internal/service/connectors/service_test.go
@@ -60,6 +60,7 @@ func TestServiceListsConnectorsAndBuildsAuthURL(t *testing.T) {
 	}
 
 	if err = service.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: auth.SystemUserID,
 		ConnectorID: "github",
 		State:       "connected",
 		Credentials: `{"access_token":"token"}`,
@@ -67,7 +68,7 @@ func TestServiceListsConnectorsAndBuildsAuthURL(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("写入连接状态失败: %v", err)
 	}
-	count, err := service.GetConnectedCount(ctx)
+	count, err := service.GetConnectedCount(ctx, auth.SystemUserID)
 	if err != nil {
 		t.Fatalf("读取已连接数量失败: %v", err)
 	}
@@ -454,6 +455,7 @@ func TestServiceEncryptsConnectionCredentials(t *testing.T) {
 	ctx := context.Background()
 	service := NewService(cfg, db)
 	if err = service.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: auth.SystemUserID,
 		ConnectorID: "github",
 		State:       "connected",
 		Credentials: `{"access_token":"secret-token"}`,
@@ -465,7 +467,7 @@ func TestServiceEncryptsConnectionCredentials(t *testing.T) {
 	var credentialText string
 	var encrypted sql.NullString
 	//goland:noinspection SqlResolve
-	if err = db.QueryRowContext(ctx, "SELECT credentials, credentials_encrypted FROM connector_connections WHERE connector_id = ?", "github").Scan(&credentialText, &encrypted); err != nil {
+	if err = db.QueryRowContext(ctx, "SELECT credentials, credentials_encrypted FROM connector_connections WHERE owner_user_id = ? AND connector_id = ?", auth.SystemUserID, "github").Scan(&credentialText, &encrypted); err != nil {
 		t.Fatalf("读取连接凭证失败: %v", err)
 	}
 	if credentialText != "__encrypted__" {
@@ -501,6 +503,7 @@ func TestServiceLoadActiveConnectionDecryptsAccessToken(t *testing.T) {
 	service := NewService(cfg, db)
 	ctx := context.Background()
 	if err = service.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: auth.SystemUserID,
 		ConnectorID: "github",
 		State:       "connected",
 		Credentials: `{"access_token":"token","scope":"repo"}`,
@@ -529,6 +532,62 @@ func TestServiceLoadActiveConnectionDecryptsAccessToken(t *testing.T) {
 	}
 }
 
+func TestServiceLoadActiveConnectionIsScopedByOwnerUserID(t *testing.T) {
+	cfg := newConnectorsTestConfig(t)
+	cfg.ConnectorCredentialsKey = testConnectorCredentialKey()
+	migrateConnectorsSQLite(t, cfg.DatabaseURL)
+
+	db, err := sql.Open("sqlite", cfg.DatabaseURL)
+	if err != nil {
+		t.Fatalf("打开测试数据库失败: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	service := NewService(cfg, db)
+	ctx := context.Background()
+	if err = service.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: "user-a",
+		ConnectorID: "github",
+		State:       "connected",
+		Credentials: `{"access_token":"token-from-user-a","scope":"repo"}`,
+		AuthType:    "oauth2",
+	}); err != nil {
+		t.Fatalf("写入 user-a 连接状态失败: %v", err)
+	}
+
+	item, err := service.LoadActiveConnection(ctx, "user-b", "github")
+	if err != nil {
+		t.Fatalf("按 user-b 读取连接失败: %v", err)
+	}
+	if item != nil {
+		t.Fatalf("user-b 不应读到 user-a 的连接: %+v", item)
+	}
+
+	items, err := service.ListActiveConnections(ctx, "user-b")
+	if err != nil {
+		t.Fatalf("列出 user-b 连接失败: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("user-b 不应看到任何连接: %+v", items)
+	}
+
+	count, err := service.GetConnectedCount(ctx, "user-b")
+	if err != nil {
+		t.Fatalf("统计 user-b 连接失败: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("user-b 已连接数量不正确: got=%d want=0", count)
+	}
+
+	ownerItems, err := service.ListActiveConnections(ctx, "user-a")
+	if err != nil {
+		t.Fatalf("列出 user-a 连接失败: %v", err)
+	}
+	if len(ownerItems) != 1 || ownerItems[0].AccessToken != "token-from-user-a" {
+		t.Fatalf("user-a 连接列表不正确: %+v", ownerItems)
+	}
+}
+
 func TestServiceLoadActiveConnectionRequiresAccessToken(t *testing.T) {
 	cfg := newConnectorsTestConfig(t)
 	migrateConnectorsSQLite(t, cfg.DatabaseURL)
@@ -542,6 +601,7 @@ func TestServiceLoadActiveConnectionRequiresAccessToken(t *testing.T) {
 	service := NewService(cfg, db)
 	ctx := context.Background()
 	if err = service.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: auth.SystemUserID,
 		ConnectorID: "github",
 		State:       "connected",
 		Credentials: `{"scope":"repo"}`,
@@ -595,6 +655,7 @@ func TestServiceLoadActiveConnectionRefreshesExpiredFeishuDocxToken(t *testing.T
 		t.Fatalf("保存飞书 OAuth Client 失败: %v", err)
 	}
 	if err = service.upsertConnection(ctx, connectionRecord{
+		OwnerUserID: auth.SystemUserID,
 		ConnectorID: "feishu-docx",
 		State:       "connected",
 		Credentials: `{"access_token":"old-feishu-docx-token","refresh_token":"old-refresh","expires_at":"1","scope":"docx:document"}`,


### PR DESCRIPTION
## Summary
- add owner_user_id scoping to connector connection storage and queries
- add sqlite/postgres migrations for composite primary key and owner-state index
- wire owner scoping through connector/capability handlers and add regression coverage

## Verification
- go test ./internal/service/connectors ./internal/handler/connector ./internal/handler/capability ./internal/runtime/mcp/connectors/tool
- go test ./...

Fixes #126