### PR TITLE
fix: #128 web/.npmrc pins npmmirror, so pnpm audit cannot run by default

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -50,7 +50,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM ${NODE_IMAGE} AS web-builder
 
-ARG PNPM_REGISTRY=https://registry.npmmirror.com/
+ARG PNPM_REGISTRY=https://registry.npmjs.org/
 ARG PNPM_VERSION=9.15.2
 ARG VITE_WS_URL=
 ARG VITE_API_URL=
@@ -82,10 +82,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG APT_MIRROR=http://mirrors.tuna.tsinghua.edu.cn
 ARG DEBIAN_SECURITY_MIRROR=http://mirrors.tuna.tsinghua.edu.cn/debian-security
-ARG PNPM_REGISTRY=https://registry.npmmirror.com/
+ARG PNPM_REGISTRY=https://registry.npmjs.org/
 ARG PNPM_VERSION=9.15.2
 ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
-ARG BUN_CONFIG_REGISTRY=https://registry.npmmirror.com/
+ARG BUN_CONFIG_REGISTRY=https://registry.npmjs.org/
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     if [ -f /etc/apt/sources.list.d/debian.sources ]; then \

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -18,10 +18,10 @@ services:
         APT_MIRROR: ${APT_MIRROR:-http://mirrors.tuna.tsinghua.edu.cn}
         DEBIAN_SECURITY_MIRROR: ${DEBIAN_SECURITY_MIRROR:-http://mirrors.tuna.tsinghua.edu.cn/debian-security}
         GOPROXY: ${GOPROXY:-https://goproxy.cn,direct}
-        PNPM_REGISTRY: ${PNPM_REGISTRY:-https://registry.npmmirror.com/}
+        PNPM_REGISTRY: ${PNPM_REGISTRY:-https://registry.npmjs.org/}
         PNPM_VERSION: ${PNPM_VERSION:-9.15.2}
         PIP_INDEX_URL: ${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}
-        BUN_CONFIG_REGISTRY: ${BUN_CONFIG_REGISTRY:-https://registry.npmmirror.com/}
+        BUN_CONFIG_REGISTRY: ${BUN_CONFIG_REGISTRY:-https://registry.npmjs.org/}
     image: ${IMAGE:-nexus}:app-${TAG:-latest}
     restart: unless-stopped
     env_file:
@@ -30,8 +30,8 @@ services:
       TZ: ${TZ:-Asia/Shanghai}
       HOST: 0.0.0.0
       PORT: 8010
-      PNPM_REGISTRY: ${PNPM_REGISTRY:-https://registry.npmmirror.com/}
-      BUN_CONFIG_REGISTRY: ${BUN_CONFIG_REGISTRY:-https://registry.npmmirror.com/}
+      PNPM_REGISTRY: ${PNPM_REGISTRY:-https://registry.npmjs.org/}
+      BUN_CONFIG_REGISTRY: ${BUN_CONFIG_REGISTRY:-https://registry.npmjs.org/}
       PIP_INDEX_URL: ${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}
       UV_DEFAULT_INDEX: ${UV_DEFAULT_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}
       UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}
@@ -64,7 +64,7 @@ services:
         - "type=local,dest=../.buildx-cache/nginx,mode=max"
       args:
         APK_MIRROR: ${APK_MIRROR:-https://mirrors.tuna.tsinghua.edu.cn/alpine}
-        PNPM_REGISTRY: ${PNPM_REGISTRY:-https://registry.npmmirror.com/}
+        PNPM_REGISTRY: ${PNPM_REGISTRY:-https://registry.npmjs.org/}
         PNPM_VERSION: ${PNPM_VERSION:-9.15.2}
         VITE_WS_URL: ${VITE_WS_URL:-}
         VITE_API_URL: ${VITE_API_URL:-}

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 : "${DATABASE_DRIVER:=sqlite}"
 : "${DATABASE_URL:=sqlite:////home/agent/.nexus/data/nexus.db}"
-: "${PNPM_REGISTRY:=https://registry.npmmirror.com/}"
+: "${PNPM_REGISTRY:=https://registry.npmjs.org/}"
 : "${BUN_CONFIG_REGISTRY:=${PNPM_REGISTRY}}"
 : "${PIP_INDEX_URL:=https://pypi.tuna.tsinghua.edu.cn/simple}"
 : "${PIP_BREAK_SYSTEM_PACKAGES:=1}"

--- a/env.example
+++ b/env.example
@@ -20,7 +20,8 @@ MESSAGE_DEBUG_STREAM_EVENT=false
 DATABASE_DRIVER=sqlite
 DATABASE_URL=~/.nexus/data/nexus.db
 WORKSPACE_PATH=
-PNPM_REGISTRY=https://registry.npmmirror.com/
+# 默认使用 npm 官方 registry，这样 `pnpm audit` 才能直接工作；如需镜像源可按环境覆盖。
+PNPM_REGISTRY=https://registry.npmjs.org/
 # Community Skill Sources
 # SKILLS_SOURCE_URLS 支持逗号/分号/换行分隔；每项可写成 "名称|URL"。
 # URL 可指向 agentskills.json/普通索引 JSON、Git 仓库、raw SKILL.md 或 zip。

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,2 +1,2 @@
-registry=https://registry.npmmirror.com/
+registry=https://registry.npmjs.org/
 replace-registry-host=never

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 FROM node:22-bookworm-slim AS builder
 
-ARG PNPM_REGISTRY=https://registry.npmmirror.com/
+ARG PNPM_REGISTRY=https://registry.npmjs.org/
 ARG PNPM_VERSION=9.15.2
 ARG VITE_WS_URL=
 ARG VITE_API_URL=


### PR DESCRIPTION
## Summary
- switch the default pnpm registry back to npmjs so `pnpm audit` works out of the box
- keep mirror usage overrideable through `PNPM_REGISTRY` / `BUN_CONFIG_REGISTRY`
- align local web installs, Docker builds, and deploy defaults on the same safe default

## Verification
- `cd web && pnpm install --frozen-lockfile`
- `cd web && pnpm audit --prod --audit-level=moderate --json`
- `docker compose -f deploy/docker-compose.yml config`

Closes #128.
