### PR TITLE
fix: #129 Markdown renderer eagerly imports Mermaid, keeping large diagram code in the web bundle

### DIFF
--- a/web/src/features/conversation/shared/editor/editor-panel.tsx
+++ b/web/src/features/conversation/shared/editor/editor-panel.tsx
@@ -22,7 +22,7 @@ import { cn } from "@/lib/utils";
 import { useWorkspaceLiveStore } from "@/store/workspace-live";
 import { TypewriterFileView } from "@/shared/ui/feedback/typewriter-file-view";
 import { MarkdownRendererContent } from "@/features/conversation/shared/message/markdown/markdown-renderer-content";
-import { MermaidView } from "@/features/conversation/shared/message/markdown/mermaid-view";
+import { LazyMermaidView } from "@/features/conversation/shared/message/markdown/lazy-mermaid-view";
 import { ConversationResizeHandle } from "./conversation-resize-handle";
 import {
   WorkspaceFileDownloadButton,
@@ -358,7 +358,7 @@ function TextFilePreview({
 
   if (file_type === "mermaid") {
     return (
-      <MermaidView
+      <LazyMermaidView
         chart={content}
         class_name="min-h-full"
         constrain_height={false}

--- a/web/src/features/conversation/shared/message/markdown/lazy-mermaid-view.tsx
+++ b/web/src/features/conversation/shared/message/markdown/lazy-mermaid-view.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { lazy, Suspense } from "react";
+import { LoaderCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { type MermaidViewProps } from "./mermaid-view";
+
+const LazyMermaidViewInner = lazy(async () => {
+  const module = await import("./mermaid-view");
+  return { default: module.MermaidView };
+});
+
+function MermaidViewLoadingFallback({
+  class_name,
+  compact = false,
+  constrain_height = true,
+}: Pick<MermaidViewProps, "class_name" | "compact" | "constrain_height">) {
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-col overflow-hidden rounded-[8px] border border-(--divider-subtle-color) bg-(--surface-panel-background)",
+        compact ? "my-2 max-h-[360px]" : constrain_height ? "my-3 max-h-[460px]" : "min-h-0",
+        class_name,
+      )}
+    >
+      <div
+        className={cn(
+          "flex items-center justify-center px-4 text-sm text-(--text-muted)",
+          compact ? "min-h-24 py-6" : constrain_height ? "min-h-56 py-8" : "min-h-[240px] flex-1 py-8",
+        )}
+      >
+        <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+        正在加载 Mermaid 预览
+      </div>
+    </div>
+  );
+}
+
+export function LazyMermaidView(props: MermaidViewProps) {
+  return (
+    <Suspense
+      fallback={(
+        <MermaidViewLoadingFallback
+          class_name={props.class_name}
+          compact={props.compact}
+          constrain_height={props.constrain_height}
+        />
+      )}
+    >
+      <LazyMermaidViewInner {...props} />
+    </Suspense>
+  );
+}

--- a/web/src/features/conversation/shared/message/markdown/markdown-renderer-shared.tsx
+++ b/web/src/features/conversation/shared/message/markdown/markdown-renderer-shared.tsx
@@ -24,7 +24,7 @@ import { useWorkspaceFilesStore } from "@/store/workspace-files";
 import { type WorkspaceFileEntry } from "@/types/agent/agent";
 import { find_open_markdown_fence_language, read_markdown_fence_marker } from "./markdown-fence";
 import { remarkInlineHtmlTags, remarkMarkdownBreaks } from "./markdown-text-plugins";
-import { MermaidView } from "./mermaid-view";
+import { LazyMermaidView } from "./lazy-mermaid-view";
 
 import { CodeBlock } from "../blocks/code-block";
 
@@ -540,7 +540,7 @@ export function create_markdown_components(
         const language = /language-(\w+)/.exec(className || "")?.[1] || "text";
         if (language.toLowerCase() === "mermaid" || language.toLowerCase() === "mmd") {
           return (
-            <MermaidView
+            <LazyMermaidView
               chart={value}
               compact={options.compact_mermaid ?? true}
               is_streaming={options.stream_mermaid}

--- a/web/src/features/conversation/shared/message/markdown/mermaid-view.tsx
+++ b/web/src/features/conversation/shared/message/markdown/mermaid-view.tsx
@@ -27,7 +27,7 @@ import { write_text_to_clipboard } from "@/hooks/ui/clipboard";
 import { DIALOG_ICON_BUTTON_CLASS_NAME } from "@/shared/ui/dialog/dialog-styles";
 import { useMermaidSvg } from "./use-mermaid-svg";
 
-interface MermaidViewProps {
+export interface MermaidViewProps {
   chart: string;
   compact?: boolean;
   class_name?: string;

--- a/web/src/features/conversation/shared/message/markdown/use-mermaid-svg.ts
+++ b/web/src/features/conversation/shared/message/markdown/use-mermaid-svg.ts
@@ -2,11 +2,19 @@
 
 import { useEffect, useRef, useState } from "react";
 import DOMPurify from "dompurify";
-import mermaid from "mermaid";
 
 import { postProcessMermaidSvg } from "./mermaid-svg-postprocess";
 
 const MERMAID_STREAM_RENDER_DELAY = 300;
+
+type MermaidModule = typeof import("mermaid")["default"];
+
+let mermaid_module_promise: Promise<MermaidModule> | null = null;
+
+function loadMermaidModule(): Promise<MermaidModule> {
+  mermaid_module_promise ??= import("mermaid").then((module) => module.default);
+  return mermaid_module_promise;
+}
 
 const MERMAID_CONFIG = {
   htmlLabels: false,
@@ -71,6 +79,7 @@ export function useMermaidSvg(
 
     const render = async () => {
       try {
+        const mermaid = await loadMermaidModule();
         mermaid.initialize(MERMAID_CONFIG);
         const parse_result = await mermaid.parse(normalized_chart, { suppressErrors: true });
         if (!parse_result) {


### PR DESCRIPTION
## Summary
- lazy-load the Mermaid preview component from markdown rendering and workspace file preview paths
- defer importing the `mermaid` runtime until a Mermaid diagram is actually rendered
- keep a lightweight loading fallback so Mermaid blocks still render cleanly once requested

## Verification
- `cd web && pnpm install --frozen-lockfile`
- `cd web && pnpm run lint`
- `cd web && pnpm run typecheck`
- `cd web && pnpm run build`

Closes #129.
