### PR TITLE
fix: #134 Add PR-time Windows desktop build validation instead of waiting until release publish

### DIFF
--- a/.github/workflows/windows-desktop-build.yml
+++ b/.github/workflows/windows-desktop-build.yml
@@ -1,0 +1,41 @@
+name: Windows Desktop Build
+
+on:
+  pull_request:
+    paths:
+      - "desktop/windows/**"
+      - "scripts/desktop/**"
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "desktop/windows/**"
+      - "scripts/desktop/**"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build:
+    name: Validate Windows desktop build
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build Windows desktop shell
+        shell: pwsh
+        run: |
+          dotnet build desktop/windows/Nexus.Desktop/Nexus.Desktop.csproj `
+            -c Release


### PR DESCRIPTION
## Summary
- add a dedicated Windows desktop build workflow for pull requests and main pushes
- trigger the validation only when Windows desktop code, desktop scripts, or workflow files change
- run a lightweight `dotnet build` guard on `windows-latest` instead of waiting for release packaging

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/workflows/windows-desktop-build.yml"); raise "missing jobs" unless data["jobs"]'`

Fixes #134.