### PR TITLE
[codex] Fix Claude Code command detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed desktop Agent startup failing to find Claude Code from native, Homebrew, Linux package, or common Node version-manager installs when GUI launches omit shell PATH entries, and expanded missing-command guidance with diagnostic and install commands.
+
 ## [0.1.13] - 2026-06-02
 
 ### Added

--- a/internal/handler/websocket/handler.go
+++ b/internal/handler/websocket/handler.go
@@ -560,7 +560,7 @@ func chatErrorDetail(err error) string {
 		strings.Contains(message, "claude.exe") ||
 		strings.Contains(message, "claude.cmd") ||
 		strings.Contains(message, "claude.ps1"):
-		return "未找到 Claude Code 命令，Agent 无法启动。请先安装 Claude Code，并在 PowerShell 里运行 `claude` 完成登录；如果已经安装，请确认 `claude` 在 PATH 中可用，或设置 NEXUS_CLAUDE_COMMAND_PATH 指向 claude.exe/claude.cmd。"
+		return "未找到 Claude Code 命令，Agent 无法启动。请先排查：macOS/Linux/WSL 运行 `command -v claude && claude --version && claude doctor`，Windows PowerShell 运行 `where.exe claude; claude --version; claude doctor`。如果尚未安装，可选择官方安装命令：macOS/Linux/WSL `curl -fsSL https://claude.ai/install.sh | bash`，macOS Homebrew `brew install --cask claude-code`，Windows PowerShell `irm https://claude.ai/install.ps1 | iex`，Windows WinGet `winget install Anthropic.ClaudeCode`，npm `npm install -g @anthropic-ai/claude-code`。安装后运行 `claude` 完成登录；如果终端可用但 Nexus 仍找不到，请设置 NEXUS_CLAUDE_COMMAND_PATH 指向可执行文件，例如 `~/.local/bin/claude`、`/opt/homebrew/bin/claude` 或 `claude.cmd`。"
 	case strings.Contains(message, "LLM Provider") ||
 		strings.Contains(message, "provider=") ||
 		strings.Contains(message, "Provider"):

--- a/internal/handler/websocket/handler_error_test.go
+++ b/internal/handler/websocket/handler_error_test.go
@@ -8,7 +8,14 @@ import (
 
 func TestChatErrorDetailExplainsMissingClaudeCommand(t *testing.T) {
 	message := chatErrorDetail(errors.New(`client: backend executable "process backend" not found: process: cli executable "claude.exe" not found`))
-	if !strings.Contains(message, "Claude Code") || !strings.Contains(message, "NEXUS_CLAUDE_COMMAND_PATH") {
+	if !strings.Contains(message, "Claude Code") ||
+		!strings.Contains(message, "NEXUS_CLAUDE_COMMAND_PATH") ||
+		!strings.Contains(message, "command -v claude") ||
+		!strings.Contains(message, "claude doctor") ||
+		!strings.Contains(message, "brew install --cask claude-code") ||
+		!strings.Contains(message, "winget install Anthropic.ClaudeCode") ||
+		!strings.Contains(message, "~/.local/bin/claude") ||
+		!strings.Contains(message, "/opt/homebrew/bin/claude") {
 		t.Fatalf("缺少 Claude Code 时应返回可执行提示: %q", message)
 	}
 }

--- a/internal/runtime/clientopts/options_claude_command.go
+++ b/internal/runtime/clientopts/options_claude_command.go
@@ -25,6 +25,7 @@ func processCLICommandConfig() claudeCommandConfig {
 			info, err := os.Stat(path)
 			return err == nil && !info.IsDir()
 		},
+		filepath.Glob,
 	)
 }
 
@@ -33,8 +34,9 @@ func resolveClaudeCommandConfigWith(
 	getenv func(string) string,
 	lookPath func(string) (string, error),
 	fileExists func(string) bool,
+	globPaths func(string) ([]string, error),
 ) claudeCommandConfig {
-	commandPath := resolveClaudeCommandPathWith(goos, getenv, lookPath, fileExists)
+	commandPath := resolveClaudeCommandPathWith(goos, getenv, lookPath, fileExists, globPaths)
 	if goos != "windows" || strings.TrimSpace(commandPath) == "" {
 		return claudeCommandConfig{CLIPath: commandPath}
 	}
@@ -49,26 +51,55 @@ func resolveClaudeCommandPathWith(
 	getenv func(string) string,
 	lookPath func(string) (string, error),
 	fileExists func(string) bool,
+	globPaths func(string) ([]string, error),
 ) string {
 	if override := strings.TrimSpace(getenv(nexusClaudeCommandPathEnvName)); override != "" {
 		return override
 	}
-	if goos != "windows" {
-		return ""
-	}
 
-	// Windows 的 npm 全局安装通常只提供 claude.cmd/claude.ps1，默认查 claude.exe 会漏掉它。
-	for _, name := range []string{"claude.exe", "claude.cmd", "claude.ps1", "claude"} {
+	for _, name := range claudeCommandNames(goos) {
 		if path, err := lookPath(name); err == nil && strings.TrimSpace(path) != "" {
 			return path
 		}
 	}
-	for _, candidate := range knownWindowsClaudeCommandPaths(getenv) {
+	for _, candidate := range knownClaudeCommandPaths(goos, getenv) {
+		if fileExists(candidate) {
+			return candidate
+		}
+	}
+	for _, candidate := range knownClaudeCommandPathGlobs(goos, getenv, globPaths) {
 		if fileExists(candidate) {
 			return candidate
 		}
 	}
 	return ""
+}
+
+func claudeCommandNames(goos string) []string {
+	if goos == "windows" {
+		// Windows 的 npm 全局安装通常只提供 claude.cmd/claude.ps1，默认查 claude.exe 会漏掉它。
+		return []string{"claude.exe", "claude.cmd", "claude.ps1", "claude"}
+	}
+	return []string{"claude"}
+}
+
+func knownClaudeCommandPaths(goos string, getenv func(string) string) []string {
+	switch goos {
+	case "windows":
+		return knownWindowsClaudeCommandPaths(getenv)
+	case "darwin":
+		return knownDarwinClaudeCommandPaths(getenv)
+	default:
+		candidates := []string{
+			"/usr/local/bin/claude",
+			"/usr/bin/claude",
+			"/home/linuxbrew/.linuxbrew/bin/claude",
+		}
+		if homebrewPrefix := strings.TrimSpace(getenv("HOMEBREW_PREFIX")); homebrewPrefix != "" {
+			candidates = append([]string{filepath.Join(homebrewPrefix, "bin", "claude")}, candidates...)
+		}
+		return knownUnixClaudeCommandPaths(getenv, candidates)
+	}
 }
 
 func windowsNodeClaudeCommandConfig(
@@ -132,6 +163,103 @@ func knownWindowsClaudeCommandPaths(getenv func(string) string) []string {
 	return candidates
 }
 
+func knownDarwinClaudeCommandPaths(getenv func(string) string) []string {
+	candidates := []string{
+		"/opt/homebrew/bin/claude",
+		"/usr/local/bin/claude",
+	}
+	if homebrewPrefix := strings.TrimSpace(getenv("HOMEBREW_PREFIX")); homebrewPrefix != "" {
+		candidates = append([]string{filepath.Join(homebrewPrefix, "bin", "claude")}, candidates...)
+	}
+	candidates = append(candidates, knownUserClaudeCommandPaths(getenv)...)
+	if home := strings.TrimSpace(getenv("HOME")); home != "" {
+		candidates = append(candidates, filepath.Join(home, "Library", "pnpm", "claude"))
+	}
+	candidates = append(candidates, knownPackageManagerClaudeCommandPaths(getenv)...)
+	return compactClaudeCommandCandidates(candidates)
+}
+
+func knownUnixClaudeCommandPaths(getenv func(string) string, systemCandidates []string) []string {
+	candidates := append([]string(nil), systemCandidates...)
+	candidates = append(candidates, knownUserClaudeCommandPaths(getenv)...)
+	candidates = append(candidates, knownPackageManagerClaudeCommandPaths(getenv)...)
+	return compactClaudeCommandCandidates(candidates)
+}
+
+func knownUserClaudeCommandPaths(getenv func(string) string) []string {
+	home := strings.TrimSpace(getenv("HOME"))
+	if home == "" {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, ".local", "bin", "claude"),
+		filepath.Join(home, ".claude", "local", "claude"),
+		filepath.Join(home, ".npm-global", "bin", "claude"),
+		filepath.Join(home, ".volta", "bin", "claude"),
+		filepath.Join(home, ".asdf", "shims", "claude"),
+		filepath.Join(home, ".local", "share", "mise", "shims", "claude"),
+		filepath.Join(home, ".local", "share", "pnpm", "claude"),
+	}
+}
+
+func knownPackageManagerClaudeCommandPaths(getenv func(string) string) []string {
+	candidates := []string{}
+	if nvmBin := strings.TrimSpace(getenv("NVM_BIN")); nvmBin != "" {
+		candidates = append(candidates, filepath.Join(nvmBin, "claude"))
+	}
+	if fnmMultishellPath := strings.TrimSpace(getenv("FNM_MULTISHELL_PATH")); fnmMultishellPath != "" {
+		candidates = append(candidates, filepath.Join(fnmMultishellPath, "bin", "claude"))
+	}
+	if npmPrefix := strings.TrimSpace(getenv("NPM_CONFIG_PREFIX")); npmPrefix != "" {
+		candidates = append(candidates, filepath.Join(npmPrefix, "bin", "claude"))
+	}
+	if pnpmHome := strings.TrimSpace(getenv("PNPM_HOME")); pnpmHome != "" {
+		candidates = append(candidates, filepath.Join(pnpmHome, "claude"))
+	}
+	if voltaHome := strings.TrimSpace(getenv("VOLTA_HOME")); voltaHome != "" {
+		candidates = append(candidates, filepath.Join(voltaHome, "bin", "claude"))
+	}
+	if asdfDataDir := strings.TrimSpace(getenv("ASDF_DATA_DIR")); asdfDataDir != "" {
+		candidates = append(candidates, filepath.Join(asdfDataDir, "shims", "claude"))
+	}
+	if miseDataDir := strings.TrimSpace(getenv("MISE_DATA_DIR")); miseDataDir != "" {
+		candidates = append(candidates, filepath.Join(miseDataDir, "shims", "claude"))
+	}
+	return candidates
+}
+
+func knownClaudeCommandPathGlobs(
+	goos string,
+	getenv func(string) string,
+	globPaths func(string) ([]string, error),
+) []string {
+	if goos == "windows" || globPaths == nil {
+		return nil
+	}
+	patterns := []string{}
+	if home := strings.TrimSpace(getenv("HOME")); home != "" {
+		patterns = append(patterns,
+			filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "claude"),
+			filepath.Join(home, ".fnm", "node-versions", "*", "installation", "bin", "claude"),
+		)
+	}
+	if nvmDir := strings.TrimSpace(getenv("NVM_DIR")); nvmDir != "" {
+		patterns = append(patterns, filepath.Join(nvmDir, "versions", "node", "*", "bin", "claude"))
+	}
+	if fnmDir := strings.TrimSpace(getenv("FNM_DIR")); fnmDir != "" {
+		patterns = append(patterns, filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", "claude"))
+	}
+	candidates := []string{}
+	for _, pattern := range compactClaudeCommandCandidates(patterns) {
+		matches, err := globPaths(pattern)
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, matches...)
+	}
+	return compactClaudeCommandCandidates(candidates)
+}
+
 func appendWindowsClaudeNames(candidates []string, directory string) []string {
 	return append(candidates,
 		filepath.Join(directory, "claude.exe"),
@@ -139,4 +267,21 @@ func appendWindowsClaudeNames(candidates []string, directory string) []string {
 		filepath.Join(directory, "claude.ps1"),
 		filepath.Join(directory, "claude"),
 	)
+}
+
+func compactClaudeCommandCandidates(candidates []string) []string {
+	result := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		normalized := strings.TrimSpace(candidate)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+	return result
 }

--- a/internal/runtime/clientopts/options_claude_command_test.go
+++ b/internal/runtime/clientopts/options_claude_command_test.go
@@ -13,6 +13,7 @@ func TestResolveClaudeCommandPathUsesOverride(t *testing.T) {
 		fakeEnv(map[string]string{nexusClaudeCommandPathEnvName: expected}),
 		func(string) (string, error) { return "", os.ErrNotExist },
 		func(string) bool { return false },
+		fakeGlob(nil),
 	)
 	if got != expected {
 		t.Fatalf("NEXUS_CLAUDE_COMMAND_PATH override 未生效: got=%q want=%q", got, expected)
@@ -27,6 +28,7 @@ func TestResolveClaudeCommandPathUsesWindowsNpmShim(t *testing.T) {
 		fakeEnv(map[string]string{"APPDATA": appData}),
 		func(string) (string, error) { return "", os.ErrNotExist },
 		func(path string) bool { return path == expected },
+		fakeGlob(nil),
 	)
 	if got != expected {
 		t.Fatalf("Windows npm claude.cmd 未被识别: got=%q want=%q", got, expected)
@@ -54,6 +56,7 @@ func TestResolveClaudeCommandConfigBypassesWindowsNpmShim(t *testing.T) {
 		func(path string) bool {
 			return path == shimPath || path == scriptPath
 		},
+		fakeGlob(nil),
 	)
 	if got.CLIPath != "" {
 		t.Fatalf("Windows npm shim 应切换到 node 启动，不应继续走 CLIPath: %+v", got)
@@ -81,6 +84,7 @@ func TestResolveClaudeCommandConfigFallsBackWhenShimScriptMissing(t *testing.T) 
 		func(path string) bool {
 			return path == shimPath
 		},
+		fakeGlob(nil),
 	)
 	if got.CLIPath != shimPath || got.Executable != "" || got.PathToExecutable != "" {
 		t.Fatalf("找不到 npm script 时应回退到原 CLIPath: %+v", got)
@@ -99,26 +103,156 @@ func TestResolveClaudeCommandPathPrefersLookPath(t *testing.T) {
 			return "", os.ErrNotExist
 		},
 		func(string) bool { return false },
+		fakeGlob(nil),
 	)
 	if got != expected {
 		t.Fatalf("PATH 中的 claude.cmd 未被优先识别: got=%q want=%q", got, expected)
 	}
 }
 
-func TestResolveClaudeCommandPathNonWindowsDefersToSDK(t *testing.T) {
+func TestResolveClaudeCommandPathNonWindowsUsesLookPath(t *testing.T) {
+	expected := "/Users/lee/.local/bin/claude"
 	got := resolveClaudeCommandPathWith(
 		"linux",
 		fakeEnv(nil),
-		func(string) (string, error) { return "/usr/local/bin/claude", nil },
-		func(string) bool { return true },
+		func(name string) (string, error) {
+			if name == "claude" {
+				return expected, nil
+			}
+			return "", os.ErrNotExist
+		},
+		func(string) bool { return false },
+		fakeGlob(nil),
+	)
+	if got != expected {
+		t.Fatalf("非 Windows PATH 中的 claude 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathUsesMacOSHomebrewPath(t *testing.T) {
+	expected := "/opt/homebrew/bin/claude"
+	got := resolveClaudeCommandPathWith(
+		"darwin",
+		fakeEnv(nil),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(path string) bool { return path == expected },
+		fakeGlob(nil),
+	)
+	if got != expected {
+		t.Fatalf("macOS Homebrew claude 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathUsesNativeInstallerPath(t *testing.T) {
+	home := "/Users/lee"
+	expected := filepath.Join(home, ".local", "bin", "claude")
+	got := resolveClaudeCommandPathWith(
+		"darwin",
+		fakeEnv(map[string]string{"HOME": home}),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(path string) bool { return path == expected },
+		fakeGlob(nil),
+	)
+	if got != expected {
+		t.Fatalf("native installer claude 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathUsesNVMGlobalInstall(t *testing.T) {
+	home := "/Users/lee"
+	expected := filepath.Join(home, ".nvm", "versions", "node", "v22.11.0", "bin", "claude")
+	pattern := filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "claude")
+	got := resolveClaudeCommandPathWith(
+		"darwin",
+		fakeEnv(map[string]string{"HOME": home}),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(path string) bool { return path == expected },
+		fakeGlob(map[string][]string{pattern: []string{expected}}),
+	)
+	if got != expected {
+		t.Fatalf("nvm npm global claude 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathUsesVoltaShim(t *testing.T) {
+	home := "/Users/lee"
+	expected := filepath.Join(home, ".volta", "bin", "claude")
+	got := resolveClaudeCommandPathWith(
+		"darwin",
+		fakeEnv(map[string]string{"HOME": home}),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(path string) bool { return path == expected },
+		fakeGlob(nil),
+	)
+	if got != expected {
+		t.Fatalf("Volta claude shim 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathUsesASDFShim(t *testing.T) {
+	home := "/Users/lee"
+	expected := filepath.Join(home, ".asdf", "shims", "claude")
+	got := resolveClaudeCommandPathWith(
+		"linux",
+		fakeEnv(map[string]string{"HOME": home}),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(path string) bool { return path == expected },
+		fakeGlob(nil),
+	)
+	if got != expected {
+		t.Fatalf("asdf claude shim 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathUsesLinuxPackagePath(t *testing.T) {
+	expected := "/usr/bin/claude"
+	got := resolveClaudeCommandPathWith(
+		"linux",
+		fakeEnv(nil),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(path string) bool { return path == expected },
+		fakeGlob(nil),
+	)
+	if got != expected {
+		t.Fatalf("Linux package manager claude 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathUsesLinuxHomebrewPath(t *testing.T) {
+	expected := "/home/linuxbrew/.linuxbrew/bin/claude"
+	got := resolveClaudeCommandPathWith(
+		"linux",
+		fakeEnv(nil),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(path string) bool { return path == expected },
+		fakeGlob(nil),
+	)
+	if got != expected {
+		t.Fatalf("Linux Homebrew claude 未被识别: got=%q want=%q", got, expected)
+	}
+}
+
+func TestResolveClaudeCommandPathFallsBackToSDKDefault(t *testing.T) {
+	got := resolveClaudeCommandPathWith(
+		"linux",
+		fakeEnv(nil),
+		func(string) (string, error) { return "", os.ErrNotExist },
+		func(string) bool { return false },
+		fakeGlob(nil),
 	)
 	if got != "" {
-		t.Fatalf("非 Windows 应继续交给 SDK 默认解析: got=%q", got)
+		t.Fatalf("找不到 claude 时应继续交给 SDK 默认解析: got=%q", got)
 	}
 }
 
 func fakeEnv(values map[string]string) func(string) string {
 	return func(key string) string {
 		return values[key]
+	}
+}
+
+func fakeGlob(values map[string][]string) func(string) ([]string, error) {
+	return func(pattern string) ([]string, error) {
+		return values[pattern], nil
 	}
 }


### PR DESCRIPTION
## Summary

Closes #136.

This fixes Desktop Agent startup when Claude Code is installed but not visible through the GUI app process PATH. The resolver now keeps `NEXUS_CLAUDE_COMMAND_PATH` as the highest-priority override, then checks PATH and common install locations across native installers, Homebrew/Linuxbrew, Linux packages, npm globals, and Node version-manager shims.

It also improves the missing-command error message with diagnostic commands, official install commands, login guidance, and override examples.

## Root Cause

The previous resolver only performed proactive command discovery on Windows. On macOS and Linux it returned an empty CLI path and relied on the SDK/process PATH. Desktop GUI launches often omit shell PATH entries such as `/opt/homebrew/bin` or Node version-manager shim directories, so valid Claude Code installs were missed.

## Validation

- `go test ./internal/runtime/clientopts ./internal/handler/websocket`
- `make check-backend`