### PR TITLE
[codex] Serialize workspace initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed workspace file previews intermittently returning internal server errors when concurrent requests reinitialized managed Skills.
 - Fixed desktop Agent startup failing to find Claude Code from native, Homebrew, Linux package, or common Node version-manager installs when GUI launches omit shell PATH entries, and expanded missing-command guidance with diagnostic and install commands.
 
 ## [0.1.13] - 2026-06-02

--- a/internal/service/workspace/initializer_workspace.go
+++ b/internal/service/workspace/initializer_workspace.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nexus-research-lab/nexus/internal/infra/appfs"
@@ -26,6 +27,8 @@ var (
 		"tools":  "TOOLS.md",
 	}
 	defaultDirs = []string{".agents", ".claude", "memory"}
+	// 中文注释：初始化会重建托管 skill 目录，同一 workspace 并发执行会互相删除正在复制的文件。
+	workspaceInitializationLocks sync.Map
 )
 
 // EnsureInitialized 保证 workspace 模板与系统技能已经落地。
@@ -40,6 +43,10 @@ func EnsureInitialized(
 	if root == "" {
 		return fmt.Errorf("workspace_path 不能为空")
 	}
+	lock := workspaceInitializationLock(root)
+	lock.Lock()
+	defer lock.Unlock()
+
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return err
 	}
@@ -106,6 +113,12 @@ func EnsureInitialized(
 		}
 	}
 	return nil
+}
+
+func workspaceInitializationLock(workspacePath string) *sync.Mutex {
+	key := filepath.Clean(strings.TrimSpace(workspacePath))
+	value, _ := workspaceInitializationLocks.LoadOrStore(key, &sync.Mutex{})
+	return value.(*sync.Mutex)
 }
 
 // BuildSkillRenderContext 构建 skill 模板渲染上下文。

--- a/internal/service/workspace/service_test.go
+++ b/internal/service/workspace/service_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -288,6 +289,35 @@ func TestEnsureInitializedWritesPromptLayerTemplates(t *testing.T) {
 	for _, fileName := range []string{"SOUL.md", "TOOLS.md", "RUNBOOK.md"} {
 		if _, err := os.Stat(filepath.Join(mainRoot, fileName)); !os.IsNotExist(err) {
 			t.Fatalf("main agent 不应默认生成 %s: %v", fileName, err)
+		}
+	}
+}
+
+func TestEnsureInitializedSerializesConcurrentSkillDeployment(t *testing.T) {
+	root := t.TempDir()
+	createdAt := time.Now()
+	const workerCount = 16
+
+	var wg sync.WaitGroup
+	errs := make(chan error, workerCount)
+	for index := 0; index < workerCount; index++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- EnsureInitialized("agent-1", "Planner", root, false, createdAt)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("并发初始化 workspace 不应互相删除托管 skill: %v", err)
+		}
+	}
+	for _, skillName := range managedSkillNames(false) {
+		if _, err := os.Stat(filepath.Join(root, ".agents", "skills", skillName, "SKILL.md")); err != nil {
+			t.Fatalf("并发初始化后托管 skill 缺失 %s: %v", skillName, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #138.

This serializes `EnsureInitialized` per workspace path so concurrent workspace requests do not rebuild managed Skill directories at the same time. Different workspaces still use separate locks.

## Root Cause

Workspace initialization can recreate managed Skill directories. When concurrent requests initialize the same workspace, one request can remove or copy files while another request is still deploying or reading the same managed Skill tree, causing intermittent internal errors in flows such as workspace file previews.

## Validation

- `go test -count=1 ./internal/service/workspace`
- `make check-backend`