### PR TITLE
:lock: Harden macOS auto-updater trust checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Room Goal creation now keeps the remote composer UI while requiring a responsible Agent selection and writing Room Goal lead/collaboration metadata.
 
 ### Fixed
+- Stopped the macOS auto-updater from stripping quarantine and added staged app bundle, code-signing, and Gatekeeper trust checks before automatic replacement.
 - Restored visible Goal creation progress in the new composer UI while objective normalization is running.
 - Fixed Go backend startup after the SDK bridge bump by adding the `v0.1.5` checksum and passing Nexus runtime kind selection through to the bridge.
 

--- a/desktop/macos/README.md
+++ b/desktop/macos/README.md
@@ -84,7 +84,7 @@ shasum -a 256 -c Nexus-macos-<version>-<build>.dmg.sha256
 xattr -dr com.apple.quarantine /Applications/Nexus.app
 ```
 
-应用启动后会按 24 小时节流后台检测 GitHub Release 中的 macOS metadata；也可以从应用菜单选择“检查更新...”。发现新版本时，Shell 会下载 `Nexus-macos-*.dmg` 或 zip 包及对应 sha256 到 `~/.nexus/cache/updates`，校验通过后提示退出、替换当前 `.app` 并自动重新打开；如果当前 App 不在可替换位置，会退回打开下载页手动处理。
+应用启动后会按 24 小时节流后台检测 GitHub Release 中的 macOS metadata；也可以从应用菜单选择“检查更新...”。发现新版本时，Shell 会下载 `Nexus-macos-*.dmg` 或 zip 包及对应 sha256 到 `~/.nexus/cache/updates`，校验 sha256、Bundle Identifier、`codesign --verify --deep --strict` 与 `spctl --assess --type execute` 全部通过后，才提示退出、替换当前 `.app` 并自动重新打开。更新器不会自动移除 quarantine；如果当前 App 不在可替换位置，或者更新包没有通过本地信任评估，会退回打开下载页手动处理。
 
 卸载或重置应用数据时，先退出 Nexus，再按需要删除：
 
@@ -93,6 +93,6 @@ xattr -dr com.apple.quarantine /Applications/Nexus.app
 
 ## 当前边界
 
-- 还没有 Developer ID 签名、公证和 Sparkle；当前 macOS 包是 ad-hoc 签名，自更新依赖 GitHub Release 包和 sha256 校验，首次打开仍可能受 Gatekeeper 策略影响。
+- 还没有 Developer ID 签名、公证和 Sparkle；当前 macOS 包是 ad-hoc 签名，自动安装必须额外通过本地签名与 Gatekeeper 评估，首次打开仍可能受 Gatekeeper 策略影响。
 - 还没有由 Go 协议真相源生成的 desktop bridge schema。
 - 还没有更完整的快捷键冲突引导、逐项 secret 级 Keychain API、occlusion 长时间/异常路径验证和多窗口生命周期细化。

--- a/desktop/macos/Sources/NexusDesktop/Update/DesktopUpdateChecker.swift
+++ b/desktop/macos/Sources/NexusDesktop/Update/DesktopUpdateChecker.swift
@@ -294,6 +294,12 @@ final class DesktopUpdateChecker {
         "staged_app": stagedAppURL.path,
       ])
 
+      try await verifyStagedAppTrust(stagedAppURL)
+      startupTimeline.mark("update_check.package_trust_verified", metadata: [
+        "latest_version": latest.version,
+        "staged_app": stagedAppURL.path,
+      ])
+
       guard promptInstall(latest, downloadedUpdate: downloadedUpdate) else {
         return
       }
@@ -448,7 +454,7 @@ final class DesktopUpdateChecker {
     更新包：\(downloadedUpdate.packageURL.lastPathComponent)
     sha256：\(downloadedUpdate.sha256Hash)
 
-    继续后 Nexus 会退出，替换当前 App，并自动重新打开。
+    更新包已通过 macOS 签名与 Gatekeeper 信任评估。继续后 Nexus 会退出，替换当前 App，并自动重新打开。
     """
     alert.alertStyle = .informational
     alert.addButton(withTitle: "退出并更新")
@@ -554,7 +560,7 @@ final class DesktopUpdateChecker {
       lines.append("")
     }
     if latest.canDownloadPackage && currentInstallTargetURL() != nil {
-      lines.append("选择“下载并更新”会下载安装包和 sha256 文件，校验通过后再询问是否退出并替换当前 App。")
+      lines.append("选择“下载并更新”会下载安装包和 sha256 文件，通过 macOS 本地信任校验后再询问是否退出并替换当前 App。")
     } else {
       lines.append("当前 Release 缺少可自动校验的 macOS 安装包或 sha256 文件，或者当前 App 所在位置不可替换。")
     }
@@ -586,6 +592,33 @@ final class DesktopUpdateChecker {
       return nil
     }
     return appURL
+  }
+
+  private func verifyStagedAppTrust(_ stagedAppURL: URL) async throws {
+    guard let expectedBundleIdentifier = Bundle.main.bundleIdentifier,
+          !expectedBundleIdentifier.isEmpty else {
+      throw DesktopUpdateError.appBundleIdentityUnavailable
+    }
+    guard let stagedBundle = Bundle(url: stagedAppURL),
+          let actualBundleIdentifier = stagedBundle.bundleIdentifier,
+          !actualBundleIdentifier.isEmpty else {
+      throw DesktopUpdateError.appBundleIdentityUnavailable
+    }
+    guard actualBundleIdentifier == expectedBundleIdentifier else {
+      throw DesktopUpdateError.appBundleIdentityMismatch(
+        expected: expectedBundleIdentifier,
+        actual: actualBundleIdentifier
+      )
+    }
+
+    try await Self.runProcess(
+      executablePath: "/usr/bin/codesign",
+      arguments: ["--verify", "--deep", "--strict", stagedAppURL.path]
+    )
+    try await Self.runProcess(
+      executablePath: "/usr/sbin/spctl",
+      arguments: ["--assess", "--type", "execute", stagedAppURL.path]
+    )
   }
 }
 
@@ -650,7 +683,6 @@ private extension DesktopUpdateChecker {
       /bin/rm -rf "${BACKUP_APP}"
     fi
 
-    /usr/bin/xattr -dr com.apple.quarantine "${TARGET_APP}" 2>/dev/null || true
     /usr/bin/open "${TARGET_APP}"
     echo "Nexus update installer finished"
   } >> "${LOG_PATH}" 2>&1
@@ -1041,6 +1073,8 @@ private enum DesktopUpdateError: LocalizedError {
   case unsupportedPackageFormat(String)
   case appBundleNotFound
   case unsupportedInstallLocation
+  case appBundleIdentityUnavailable
+  case appBundleIdentityMismatch(expected: String, actual: String)
   case processFailed(String, Int32, String)
 
   var errorDescription: String? {
@@ -1063,6 +1097,10 @@ private enum DesktopUpdateError: LocalizedError {
       return "更新包中没有找到可替换的 Nexus.app。"
     case .unsupportedInstallLocation:
       return "当前 Nexus.app 所在位置不可自动替换。"
+    case .appBundleIdentityUnavailable:
+      return "更新包缺少可验证的 App 标识，无法自动安装。"
+    case let .appBundleIdentityMismatch(expected, actual):
+      return "更新包 App 标识不匹配，期望 \(expected)，实际 \(actual)。"
     case let .processFailed(executablePath, statusCode, output):
       let detail = output.trimmingCharacters(in: .whitespacesAndNewlines)
       if detail.isEmpty {


### PR DESCRIPTION
## Summary
- require downloaded macOS updates to match the current app bundle identifier before automatic installation
- run `codesign --verify --deep --strict` and `spctl --assess --type execute` on the staged app before prompting replacement
- stop the updater installer from stripping quarantine and document the updated trust boundary

## Verification
- `git diff --check`
- `cd desktop/macos && swift build`
- `NEXUS_DESKTOP_SKIP_CODESIGN=1 scripts/desktop/build-macos-app.sh`
- `NEXUS_DESKTOP_SKIP_CODESIGN=1 NEXUS_DESKTOP_SMOKE_ALLOW_FALLBACK=1 NEXUS_DESKTOP_SMOKE_MAIN_TIMEOUT_SECONDS=45 NEXUS_DESKTOP_SMOKE_LAUNCHER_TIMEOUT_SECONDS=30 NEXUS_DESKTOP_SMOKE_EXPECTED_CREDENTIALS_STORAGE=file scripts/desktop/smoke-macos-app.sh`

Fixes #142.