### PR TITLE
fix: #145 Web app ships react-router-dom with multiple production security advisories

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.9.5",
+    "react-router-dom": "^7.15.0",
     "react-syntax-highlighter": "^16.1.0",
     "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.7)(react@19.2.0)
       react-router-dom:
-        specifier: ^7.9.5
-        version: 7.13.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^7.15.0
+        version: 7.15.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.0(react@19.2.0)
@@ -2079,15 +2079,15 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.13.1:
-    resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
+  react-router-dom@7.15.0:
+    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.13.1:
-    resolution: {integrity: sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==}
+  react-router@7.15.0:
+    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -4753,13 +4753,13 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.13.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router-dom@7.15.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-router: 7.13.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router: 7.15.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  react-router@7.13.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.15.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.1.1
       react: 19.2.0


### PR DESCRIPTION
## Summary
- bump `react-router-dom` to `^7.15.0`
- refresh the lockfile to resolve `react-router-dom` / `react-router` to `7.15.0`
- remove the React Router production advisories reported in `pnpm audit --prod`

Closes #145.

## Verification
- `cd web && npx -y pnpm@9.15.2 run lint`
- `cd web && npx -y pnpm@9.15.2 run typecheck`
- `cd web && npx -y pnpm@9.15.2 run build`
- `cd web && npx -y pnpm@9.15.2 audit --prod --registry=https://registry.npmjs.org --audit-level=low`
  - React Router advisories are gone; remaining 8 vulnerabilities are from the already-tracked spreadsheet preview dependency chain.
