### PR TITLE
[codex] Reduce web shell startup preloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Reduced web shell startup preloads by lazy-loading protected app layout/session code and deferring onboarding tour overlay UI until a guide is opened.
+
 ## [0.1.17] - 2026-06-08
 
 ### Changed

--- a/web/src/app/router/app-router.tsx
+++ b/web/src/app/router/app-router.tsx
@@ -2,10 +2,17 @@ import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import { APP_ROUTE_PATHS } from "@/app/router/route-paths";
-import { AuthenticatedAppSessionRoot } from "@/app/router/authenticated-session-root";
 import { AuthGuard } from "@/app/router/auth-guard";
-import { AppLayout } from "@/shared/ui/layout/app-layout";
 import { OnboardingTourProvider } from "@/shared/ui/onboarding/tour-provider";
+
+const AuthenticatedAppSessionRoot = lazy(() =>
+  import("@/app/router/authenticated-session-root").then((m) => ({
+    default: m.AuthenticatedAppSessionRoot,
+  })),
+);
+const AppLayout = lazy(() =>
+  import("@/shared/ui/layout/app-layout").then((m) => ({ default: m.AppLayout })),
+);
 
 // 懒加载页面组件 — 首次导航时按需加载
 const LoginPage = lazy(() =>

--- a/web/src/app/router/desktop-entry-layout.tsx
+++ b/web/src/app/router/desktop-entry-layout.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from "react";
 import { Outlet } from "react-router-dom";
 
+import { cn } from "@/shared/ui/class-name";
 import { HOME_PAGE_PADDING_CLASS } from "@/lib/layout/home-layout";
-import { cn } from "@/lib/utils";
 
 export function DesktopEntryLayout({
   children,

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -7,18 +7,12 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
 import { prepareWithSegments } from '@chenglou/pretext';
+import { cn } from "@/shared/ui/class-name";
 
 // ==================== 样式工具 ====================
 
-/**
- * 合并Tailwind CSS类名
- */
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn };
 
 // ==================== 格式化工具 ====================
 

--- a/web/src/shared/ui/button-styles.ts
+++ b/web/src/shared/ui/button-styles.ts
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn } from "@/shared/ui/class-name";
 
 export type UiButtonTone = "default" | "primary" | "danger";
 export type UiButtonVariant = "surface" | "solid" | "ghost" | "text";

--- a/web/src/shared/ui/class-name.ts
+++ b/web/src/shared/ui/class-name.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/web/src/shared/ui/layout/app-loading-screen.tsx
+++ b/web/src/shared/ui/layout/app-loading-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/shared/ui/class-name";
 
 interface AppLoadingStateProps {
   class_name?: string;

--- a/web/src/shared/ui/onboarding/onboarding-guide-center.tsx
+++ b/web/src/shared/ui/onboarding/onboarding-guide-center.tsx
@@ -4,7 +4,7 @@ import { type MouseEvent } from "react";
 import { createPortal } from "react-dom";
 import { type LucideIcon, RotateCcw, X } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/shared/ui/class-name";
 import {
   DIALOG_BACKDROP_CLASS_NAME,
   DIALOG_ICON_BUTTON_CLASS_NAME,

--- a/web/src/shared/ui/onboarding/tour-overlay.tsx
+++ b/web/src/shared/ui/onboarding/tour-overlay.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { Bot, Hash, Puzzle, Users2 } from "lucide-react";
+
+import { cn } from "@/shared/ui/class-name";
+import { useI18n } from "@/shared/i18n/i18n-context";
+import type {
+  OnboardingTourDefinition,
+  OnboardingTourStep,
+  OnboardingTourStepItem,
+} from "@/shared/ui/onboarding/tour-provider";
+
+type TourPlacement = "top" | "right" | "bottom" | "left" | "center";
+type TourStickerPlacement = "hang" | "perch" | "peek" | "point" | "hold";
+
+interface TourStickerAsset {
+  src: string;
+  placement: TourStickerPlacement;
+}
+
+interface PopoverPosition {
+  top: number;
+  left: number;
+}
+
+interface PopoverSize {
+  width: number;
+  height: number;
+}
+
+const TOUR_STICKERS: TourStickerAsset[] = [
+  { src: "/nexus/stickers/card-top.png", placement: "perch" },
+  { src: "/nexus/stickers/hanging.png", placement: "hang" },
+  { src: "/nexus/stickers/peek-right.png", placement: "peek" },
+  { src: "/nexus/stickers/pointing.png", placement: "point" },
+  { src: "/nexus/stickers/holding-card.png", placement: "hold" },
+];
+
+function estimate_card_height(step?: OnboardingTourStep): number {
+  if (!step) return 180;
+  let height = 104;
+  if (step.image) height += 136;
+  if (step.description) height += 24;
+  if (step.items?.length) height += step.items.length * 34;
+  return height;
+}
+
+function clamp_popover_top_with_clearance(
+  top: number,
+  card_height: number,
+  viewport_height: number,
+  top_clearance: number,
+): number {
+  const bottom_limit = viewport_height - card_height - 16;
+  if (bottom_limit < top_clearance) {
+    return Math.max(16, bottom_limit);
+  }
+  return Math.max(top_clearance, Math.min(top, bottom_limit));
+}
+
+function clamp_popover_left(left: number, card_width: number, viewport_width: number): number {
+  return Math.max(16, Math.min(left, viewport_width - card_width - 16));
+}
+
+function resolve_tour_sticker(
+  step_index: number,
+  placement: TourPlacement,
+): TourStickerAsset {
+  if (placement === "center") {
+    return TOUR_STICKERS[0];
+  }
+  if (placement === "left") {
+    return TOUR_STICKERS[2];
+  }
+  return TOUR_STICKERS[(step_index + 1) % TOUR_STICKERS.length];
+}
+
+function TourStepSticker({ sticker }: { sticker: TourStickerAsset }) {
+  const sticker_class_name: Record<TourStickerPlacement, string> = {
+    hang: "-top-12 right-7 h-[72px] w-auto",
+    perch: "-top-10 left-14 h-[74px] w-auto -translate-x-1/2",
+    peek: "top-16 -left-10 h-[82px] w-auto",
+    point: "-top-[52px] right-4 h-[72px] w-auto",
+    hold: "top-1/2 -right-10 h-[82px] w-auto -translate-y-1/2",
+  };
+
+  return (
+    <img
+      alt=""
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute z-20 select-none drop-shadow-[0_14px_20px_rgba(68,74,120,0.12)] max-[520px]:hidden",
+        sticker_class_name[sticker.placement],
+      )}
+      src={sticker.src}
+    />
+  );
+}
+
+function get_sticker_top_clearance(sticker: TourStickerAsset): number {
+  if (sticker.placement === "hang" || sticker.placement === "perch" || sticker.placement === "point") {
+    return 72;
+  }
+  return 16;
+}
+
+function TourStepIllustration({
+  src,
+  title,
+  is_center_step,
+}: {
+  src: string;
+  title: string;
+  is_center_step: boolean;
+}) {
+  return (
+    <div className="mb-3 rounded-[12px] border border-(--divider-subtle-color) bg-transparent p-2.5">
+      <div className="relative overflow-hidden rounded-[10px] border border-(--divider-subtle-color) bg-transparent">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_18%,rgba(255,255,255,0.76),transparent_36%),radial-gradient(circle_at_82%_84%,rgba(132,146,255,0.12),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.18),transparent_68%)]" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-[linear-gradient(180deg,transparent,rgba(132,146,255,0.06))]" />
+        <img
+          alt={title}
+          className={cn(
+            "relative z-10 mx-auto w-full object-contain px-2 py-2.5 [image-rendering:auto]",
+            "drop-shadow-[0_10px_18px_rgba(87,98,173,0.10)] mix-blend-multiply",
+            is_center_step ? "h-[132px]" : "h-[112px]",
+          )}
+          src={src}
+        />
+      </div>
+    </div>
+  );
+}
+
+function get_popover_position(
+  placement: TourPlacement,
+  target_rect: DOMRect | null,
+  viewport_width: number,
+  viewport_height: number,
+  popover_size: PopoverSize,
+  top_clearance: number,
+): PopoverPosition {
+  const card_width = Math.min(popover_size.width, viewport_width - 32);
+  const card_height = Math.min(popover_size.height, viewport_height - 32);
+  const gutter = 16;
+
+  if (!target_rect || placement === "center") {
+    return {
+      top: clamp_popover_top_with_clearance(
+        viewport_height / 2 - card_height / 2,
+        card_height,
+        viewport_height,
+        top_clearance,
+      ),
+      left: clamp_popover_left(viewport_width / 2 - card_width / 2, card_width, viewport_width),
+    };
+  }
+
+  switch (placement) {
+    case "left":
+      return {
+        top: clamp_popover_top_with_clearance(
+          target_rect.top + target_rect.height / 2 - card_height / 2,
+          card_height,
+          viewport_height,
+          top_clearance,
+        ),
+        left: clamp_popover_left(target_rect.left - card_width - gutter, card_width, viewport_width),
+      };
+    case "top":
+      return {
+        top: clamp_popover_top_with_clearance(
+          target_rect.top - card_height - gutter,
+          card_height,
+          viewport_height,
+          top_clearance,
+        ),
+        left: clamp_popover_left(
+          target_rect.left + target_rect.width / 2 - card_width / 2,
+          card_width,
+          viewport_width,
+        ),
+      };
+    case "bottom":
+      return {
+        top: clamp_popover_top_with_clearance(
+          target_rect.bottom + gutter,
+          card_height,
+          viewport_height,
+          top_clearance,
+        ),
+        left: clamp_popover_left(
+          target_rect.left + target_rect.width / 2 - card_width / 2,
+          card_width,
+          viewport_width,
+        ),
+      };
+    case "right":
+    default: {
+      const raw_top = target_rect.top + target_rect.height / 2 - card_height / 2;
+      return {
+        top: clamp_popover_top_with_clearance(
+          raw_top,
+          card_height,
+          viewport_height,
+          top_clearance,
+        ),
+        left: clamp_popover_left(
+          target_rect.right + gutter,
+          card_width,
+          viewport_width,
+        ),
+      };
+    }
+  }
+}
+
+export function OnboardingTourOverlay({
+  tour,
+  step_index,
+  on_close,
+  on_next,
+  on_previous,
+}: {
+  tour: OnboardingTourDefinition;
+  step_index: number;
+  on_close: (options?: { completed?: boolean }) => void;
+  on_next: () => void;
+  on_previous: () => void;
+}) {
+  const { t } = useI18n();
+  const step = tour.steps[step_index];
+  const [target_rect, set_target_rect] = useState<DOMRect | null>(null);
+  const card_ref = useRef<HTMLDivElement | null>(null);
+  const [popover_size, set_popover_size] = useState<PopoverSize>({
+    width: Math.min(344, typeof window === "undefined" ? 344 : window.innerWidth - 32),
+    height: estimate_card_height(step),
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const update_target_rect = () => {
+      if (!step?.target) {
+        set_target_rect(null);
+        return;
+      }
+
+      const target_element = document.querySelector<HTMLElement>(
+        `[data-tour-anchor="${step.target}"]`,
+      );
+      if (!target_element) {
+        set_target_rect(null);
+        return;
+      }
+
+      target_element.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+      });
+      set_target_rect(target_element.getBoundingClientRect());
+    };
+
+    update_target_rect();
+    window.addEventListener("resize", update_target_rect);
+    window.addEventListener("scroll", update_target_rect, true);
+
+    return () => {
+      window.removeEventListener("resize", update_target_rect);
+      window.removeEventListener("scroll", update_target_rect, true);
+    };
+  }, [step?.target]);
+
+  useLayoutEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const element = card_ref.current;
+    if (!element) {
+      return undefined;
+    }
+
+    const update_size = () => {
+      const rect = element.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) {
+        return;
+      }
+      set_popover_size((current_size) => {
+        if (
+          Math.abs(current_size.width - rect.width) < 1
+          && Math.abs(current_size.height - rect.height) < 1
+        ) {
+          return current_size;
+        }
+        return {
+          width: rect.width,
+          height: rect.height,
+        };
+      });
+    };
+
+    update_size();
+
+    const resize_observer = new ResizeObserver(() => {
+      update_size();
+    });
+    resize_observer.observe(element);
+    window.addEventListener("resize", update_size);
+
+    return () => {
+      resize_observer.disconnect();
+      window.removeEventListener("resize", update_size);
+    };
+  }, [step]);
+
+  if (typeof document === "undefined" || !step) {
+    return null;
+  }
+
+  const placement = step.placement ?? (step.target ? "right" : "center");
+  const sticker = resolve_tour_sticker(step_index, placement);
+  const popover_position = get_popover_position(
+    placement,
+    target_rect,
+    window.innerWidth,
+    window.innerHeight,
+    popover_size,
+    get_sticker_top_clearance(sticker),
+  );
+  const is_last_step = step_index >= tour.steps.length - 1;
+
+  const overlay = (
+    <div className="fixed inset-0 z-[11000]">
+      <div
+        className="absolute inset-0 bg-[rgba(11,16,24,0.46)] backdrop-blur-[1px]"
+        onClick={() => on_close()}
+      />
+
+      {target_rect ? (
+        <div
+          className="pointer-events-none absolute rounded-[12px] border border-[color:color-mix(in_srgb,var(--primary)_34%,white)] shadow-[0_0_0_9999px_rgba(11,16,24,0.22),0_18px_42px_color-mix(in_srgb,var(--primary)_14%,transparent)] transition-[top,left,width,height] duration-(--motion-duration-fast)"
+          style={{
+            top: target_rect.top - 6,
+            left: target_rect.left - 6,
+            width: target_rect.width + 12,
+            height: target_rect.height + 12,
+          }}
+        />
+      ) : null}
+
+      <div
+        className="absolute"
+        style={{
+          top: popover_position.top,
+          left: popover_position.left,
+        }}
+      >
+        <div className="relative">
+          <TourStepSticker sticker={sticker} />
+          <div
+            ref={card_ref}
+            className={cn(
+              "surface-popover relative max-h-[calc(100vh-80px)] w-[min(344px,calc(100vw-32px))] overflow-y-auto rounded-[12px] border px-4 py-3.5 shadow-[0_14px_32px_color-mix(in_srgb,var(--shadow-color)_14%,transparent)]",
+            )}
+          >
+            {step.image ? (
+              <TourStepIllustration
+                is_center_step={placement === "center"}
+                src={step.image}
+                title={step.title}
+              />
+            ) : null}
+
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h3 className="mt-0.5 text-[18px] font-semibold tracking-tight text-(--text-strong)">
+                  {step.title}
+                </h3>
+              </div>
+              <button
+                className="shrink-0 rounded-full px-2 py-1 text-[11px] font-medium text-(--text-muted) transition-[background,color] duration-(--motion-duration-fast) hover:bg-(--surface-interactive-hover-background) hover:text-(--text-strong)"
+                onClick={() => on_close({ completed: true })}
+                type="button"
+              >
+                {t("common.skip")}
+              </button>
+            </div>
+
+            <p className="mt-2.5 text-[13px] leading-6 text-(--text-default)">
+              {step.description}
+            </p>
+
+            {step.items && step.items.length > 0 && (
+              <div className="mt-2.5 flex flex-col gap-1.5">
+                {step.items.map((item) => (
+                  <div
+                    key={item.text}
+                    className="flex items-center gap-2 rounded-[10px] bg-[color:color-mix(in_srgb,var(--surface-interactive-hover-background)_58%,transparent)] px-2.5 py-1.5"
+                  >
+                    <TourItemIcon name={item.icon} />
+                    <span className="text-[12px] leading-5 text-(--text-muted)">{item.text}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-3.5 flex items-center justify-between gap-3">
+              <span className="text-[11px] font-medium tabular-nums text-(--text-muted)">
+                {step_index + 1} / {tour.steps.length}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  className="rounded-full border border-(--divider-subtle-color) px-3 py-1.5 text-[11px] font-medium text-(--text-default) transition-[background,color,transform] duration-(--motion-duration-fast) hover:-translate-y-[1px] hover:bg-(--surface-interactive-hover-background) disabled:pointer-events-none disabled:opacity-(--disabled-opacity)"
+                  disabled={step_index === 0}
+                  onClick={on_previous}
+                  type="button"
+                >
+                  {t("common.back")}
+                </button>
+                <button
+                  className="rounded-full bg-(--primary) px-3 py-1.5 text-[11px] font-medium text-white transition-[transform,opacity] duration-(--motion-duration-fast) hover:-translate-y-[1px] hover:opacity-92"
+                  onClick={is_last_step ? () => on_close({ completed: true }) : on_next}
+                  type="button"
+                >
+                  {is_last_step ? t("common.finish") : t("common.next")}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(overlay, document.body);
+}
+
+function TourItemIcon({ name }: { name: OnboardingTourStepItem["icon"] }) {
+  const class_name = "h-3.5 w-3.5 shrink-0 text-(--icon-muted)";
+  if (name === "bot") return <Bot className={class_name} />;
+  if (name === "users") return <Users2 className={class_name} />;
+  if (name === "hash") return <Hash className={class_name} />;
+  return <Puzzle className={class_name} />;
+}

--- a/web/src/shared/ui/onboarding/tour-provider.tsx
+++ b/web/src/shared/ui/onboarding/tour-provider.tsx
@@ -1,20 +1,16 @@
 "use client";
 
 import {
+  lazy,
   type ReactNode,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  Suspense,
 } from "react";
-import { createPortal } from "react-dom";
 
-import { Bot, Hash, Puzzle, Users2 } from "lucide-react";
-
-import { cn } from "@/lib/utils";
-import { useI18n } from "@/shared/i18n/i18n-context";
 import { ONBOARDING_TOUR_CONTEXT } from "@/shared/ui/onboarding/tour-context";
 import {
   hydrate_onboarding_state_from_desktop,
@@ -24,12 +20,6 @@ import {
 } from "@/shared/ui/onboarding/tour-state";
 
 type TourPlacement = "top" | "right" | "bottom" | "left" | "center";
-type TourStickerPlacement = "hang" | "perch" | "peek" | "point" | "hold";
-
-interface TourStickerAsset {
-  src: string;
-  placement: TourStickerPlacement;
-}
 
 export interface OnboardingTourStepItem {
   icon: "bot" | "users" | "hash" | "puzzle";
@@ -71,431 +61,17 @@ export interface OnboardingTourContextValue {
   reset_version: number;
 }
 
-const TOUR_STICKERS: TourStickerAsset[] = [
-  { src: "/nexus/stickers/card-top.png", placement: "perch" },
-  { src: "/nexus/stickers/hanging.png", placement: "hang" },
-  { src: "/nexus/stickers/peek-right.png", placement: "peek" },
-  { src: "/nexus/stickers/pointing.png", placement: "point" },
-  { src: "/nexus/stickers/holding-card.png", placement: "hold" },
-];
+const OnboardingTourOverlay = lazy(() =>
+  import("@/shared/ui/onboarding/tour-overlay").then((m) => ({
+    default: m.OnboardingTourOverlay,
+  })),
+);
 
 function clamp_step_index(step_index: number, steps_count: number): number {
   if (steps_count <= 0) {
     return 0;
   }
   return Math.max(0, Math.min(step_index, steps_count - 1));
-}
-
-interface PopoverPosition {
-  top: number;
-  left: number;
-}
-
-interface PopoverSize {
-  width: number;
-  height: number;
-}
-
-function estimate_card_height(step?: OnboardingTourStep): number {
-  if (!step) return 180;
-  let height = 104;
-  if (step.image) height += 136;
-  if (step.description) height += 24;
-  if (step.items?.length) height += step.items.length * 34;
-  return height;
-}
-
-function clamp_popover_top_with_clearance(
-  top: number,
-  card_height: number,
-  viewport_height: number,
-  top_clearance: number,
-): number {
-  const bottom_limit = viewport_height - card_height - 16;
-  if (bottom_limit < top_clearance) {
-    return Math.max(16, bottom_limit);
-  }
-  return Math.max(top_clearance, Math.min(top, bottom_limit));
-}
-
-function clamp_popover_left(left: number, card_width: number, viewport_width: number): number {
-  return Math.max(16, Math.min(left, viewport_width - card_width - 16));
-}
-
-function resolve_tour_sticker(
-  step_index: number,
-  placement: TourPlacement,
-): TourStickerAsset {
-  if (placement === "center") {
-    return TOUR_STICKERS[0];
-  }
-  if (placement === "left") {
-    return TOUR_STICKERS[2];
-  }
-  return TOUR_STICKERS[(step_index + 1) % TOUR_STICKERS.length];
-}
-
-function TourStepSticker({ sticker }: { sticker: TourStickerAsset }) {
-  const sticker_class_name: Record<TourStickerPlacement, string> = {
-    hang: "-top-12 right-7 h-[72px] w-auto",
-    perch: "-top-10 left-14 h-[74px] w-auto -translate-x-1/2",
-    peek: "top-16 -left-10 h-[82px] w-auto",
-    point: "-top-[52px] right-4 h-[72px] w-auto",
-    hold: "top-1/2 -right-10 h-[82px] w-auto -translate-y-1/2",
-  };
-
-  return (
-    <img
-      alt=""
-      aria-hidden="true"
-      className={cn(
-        "pointer-events-none absolute z-20 select-none drop-shadow-[0_14px_20px_rgba(68,74,120,0.12)] max-[520px]:hidden",
-        sticker_class_name[sticker.placement],
-      )}
-      src={sticker.src}
-    />
-  );
-}
-
-function get_sticker_top_clearance(sticker: TourStickerAsset): number {
-  if (sticker.placement === "hang" || sticker.placement === "perch" || sticker.placement === "point") {
-    return 72;
-  }
-  return 16;
-}
-
-function TourStepIllustration({
-  src,
-  title,
-  is_center_step,
-}: {
-  src: string;
-  title: string;
-  is_center_step: boolean;
-}) {
-  return (
-    <div className="mb-3 rounded-[12px] border border-(--divider-subtle-color) bg-transparent p-2.5">
-      <div className="relative overflow-hidden rounded-[10px] border border-(--divider-subtle-color) bg-transparent">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_18%,rgba(255,255,255,0.76),transparent_36%),radial-gradient(circle_at_82%_84%,rgba(132,146,255,0.12),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.18),transparent_68%)]" />
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-[linear-gradient(180deg,transparent,rgba(132,146,255,0.06))]" />
-        <img
-          alt={title}
-          className={cn(
-            "relative z-10 mx-auto w-full object-contain px-2 py-2.5 [image-rendering:auto]",
-            "drop-shadow-[0_10px_18px_rgba(87,98,173,0.10)] mix-blend-multiply",
-            is_center_step ? "h-[132px]" : "h-[112px]",
-          )}
-          src={src}
-        />
-      </div>
-    </div>
-  );
-}
-
-function get_popover_position(
-  placement: TourPlacement,
-  target_rect: DOMRect | null,
-  viewport_width: number,
-  viewport_height: number,
-  popover_size: PopoverSize,
-  top_clearance: number,
-): PopoverPosition {
-  const card_width = Math.min(popover_size.width, viewport_width - 32);
-  const card_height = Math.min(popover_size.height, viewport_height - 32);
-  const gutter = 16;
-
-  if (!target_rect || placement === "center") {
-    return {
-      top: clamp_popover_top_with_clearance(
-        viewport_height / 2 - card_height / 2,
-        card_height,
-        viewport_height,
-        top_clearance,
-      ),
-      left: clamp_popover_left(viewport_width / 2 - card_width / 2, card_width, viewport_width),
-    };
-  }
-
-  switch (placement) {
-    case "left":
-      return {
-        top: clamp_popover_top_with_clearance(
-          target_rect.top + target_rect.height / 2 - card_height / 2,
-          card_height,
-          viewport_height,
-          top_clearance,
-        ),
-        left: clamp_popover_left(target_rect.left - card_width - gutter, card_width, viewport_width),
-      };
-    case "top":
-      return {
-        top: clamp_popover_top_with_clearance(
-          target_rect.top - card_height - gutter,
-          card_height,
-          viewport_height,
-          top_clearance,
-        ),
-        left: clamp_popover_left(
-          target_rect.left + target_rect.width / 2 - card_width / 2,
-          card_width,
-          viewport_width,
-        ),
-      };
-    case "bottom":
-      return {
-        top: clamp_popover_top_with_clearance(
-          target_rect.bottom + gutter,
-          card_height,
-          viewport_height,
-          top_clearance,
-        ),
-        left: clamp_popover_left(
-          target_rect.left + target_rect.width / 2 - card_width / 2,
-          card_width,
-          viewport_width,
-        ),
-      };
-    case "right":
-    default: {
-      const raw_top = target_rect.top + target_rect.height / 2 - card_height / 2;
-      return {
-        top: clamp_popover_top_with_clearance(
-          raw_top,
-          card_height,
-          viewport_height,
-          top_clearance,
-        ),
-        left: clamp_popover_left(
-          target_rect.right + gutter,
-          card_width,
-          viewport_width,
-        ),
-      };
-    }
-  }
-}
-
-function OnboardingTourOverlay({
-  tour,
-  step_index,
-  on_close,
-  on_next,
-  on_previous,
-}: {
-  tour: OnboardingTourDefinition;
-  step_index: number;
-  on_close: (options?: { completed?: boolean }) => void;
-  on_next: () => void;
-  on_previous: () => void;
-}) {
-  const { t } = useI18n();
-  const step = tour.steps[step_index];
-  const [target_rect, set_target_rect] = useState<DOMRect | null>(null);
-  const card_ref = useRef<HTMLDivElement | null>(null);
-  const [popover_size, set_popover_size] = useState<PopoverSize>({
-    width: Math.min(344, typeof window === "undefined" ? 344 : window.innerWidth - 32),
-    height: estimate_card_height(step),
-  });
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return undefined;
-    }
-
-    const update_target_rect = () => {
-      if (!step?.target) {
-        set_target_rect(null);
-        return;
-      }
-
-      const target_element = document.querySelector<HTMLElement>(
-        `[data-tour-anchor="${step.target}"]`,
-      );
-      if (!target_element) {
-        set_target_rect(null);
-        return;
-      }
-
-      target_element.scrollIntoView({
-        block: "nearest",
-        inline: "nearest",
-      });
-      set_target_rect(target_element.getBoundingClientRect());
-    };
-
-    update_target_rect();
-    window.addEventListener("resize", update_target_rect);
-    window.addEventListener("scroll", update_target_rect, true);
-
-    return () => {
-      window.removeEventListener("resize", update_target_rect);
-      window.removeEventListener("scroll", update_target_rect, true);
-    };
-  }, [step?.target]);
-
-  useLayoutEffect(() => {
-    if (typeof window === "undefined") {
-      return undefined;
-    }
-
-    const element = card_ref.current;
-    if (!element) {
-      return undefined;
-    }
-
-    const update_size = () => {
-      const rect = element.getBoundingClientRect();
-      if (rect.width <= 0 || rect.height <= 0) {
-        return;
-      }
-      set_popover_size((current_size) => {
-        if (
-          Math.abs(current_size.width - rect.width) < 1
-          && Math.abs(current_size.height - rect.height) < 1
-        ) {
-          return current_size;
-        }
-        return {
-          width: rect.width,
-          height: rect.height,
-        };
-      });
-    };
-
-    update_size();
-
-    const resize_observer = new ResizeObserver(() => {
-      update_size();
-    });
-    resize_observer.observe(element);
-    window.addEventListener("resize", update_size);
-
-    return () => {
-      resize_observer.disconnect();
-      window.removeEventListener("resize", update_size);
-    };
-  }, [step]);
-
-  if (typeof document === "undefined" || !step) {
-    return null;
-  }
-
-  const placement = step.placement ?? (step.target ? "right" : "center");
-  const sticker = resolve_tour_sticker(step_index, placement);
-  const popover_position = get_popover_position(
-    placement,
-    target_rect,
-    window.innerWidth,
-    window.innerHeight,
-    popover_size,
-    get_sticker_top_clearance(sticker),
-  );
-  const is_last_step = step_index >= tour.steps.length - 1;
-
-  const overlay = (
-    <div className="fixed inset-0 z-[11000]">
-      <div
-        className="absolute inset-0 bg-[rgba(11,16,24,0.46)] backdrop-blur-[1px]"
-        onClick={() => on_close()}
-      />
-
-      {target_rect ? (
-        <div
-          className="pointer-events-none absolute rounded-[12px] border border-[color:color-mix(in_srgb,var(--primary)_34%,white)] shadow-[0_0_0_9999px_rgba(11,16,24,0.22),0_18px_42px_color-mix(in_srgb,var(--primary)_14%,transparent)] transition-[top,left,width,height] duration-(--motion-duration-fast)"
-          style={{
-            top: target_rect.top - 6,
-            left: target_rect.left - 6,
-            width: target_rect.width + 12,
-            height: target_rect.height + 12,
-          }}
-        />
-      ) : null}
-
-      <div
-        className="absolute"
-        style={{
-          top: popover_position.top,
-          left: popover_position.left,
-        }}
-      >
-        <div className="relative">
-          <TourStepSticker sticker={sticker} />
-          <div
-            ref={card_ref}
-            className={cn(
-              "surface-popover relative max-h-[calc(100vh-80px)] w-[min(344px,calc(100vw-32px))] overflow-y-auto rounded-[12px] border px-4 py-3.5 shadow-[0_14px_32px_color-mix(in_srgb,var(--shadow-color)_14%,transparent)]",
-            )}
-          >
-            {step.image ? (
-              <TourStepIllustration
-                is_center_step={placement === "center"}
-                src={step.image}
-                title={step.title}
-              />
-            ) : null}
-
-            <div className="flex items-start justify-between gap-4">
-              <div className="min-w-0">
-                <h3 className="mt-0.5 text-[18px] font-semibold tracking-tight text-(--text-strong)">
-                  {step.title}
-                </h3>
-              </div>
-              <button
-                className="shrink-0 rounded-full px-2 py-1 text-[11px] font-medium text-(--text-muted) transition-[background,color] duration-(--motion-duration-fast) hover:bg-(--surface-interactive-hover-background) hover:text-(--text-strong)"
-                onClick={() => on_close({ completed: true })}
-                type="button"
-              >
-                {t("common.skip")}
-              </button>
-            </div>
-
-            <p className="mt-2.5 text-[13px] leading-6 text-(--text-default)">
-              {step.description}
-            </p>
-
-            {step.items && step.items.length > 0 && (
-              <div className="mt-2.5 flex flex-col gap-1.5">
-                {step.items.map((item) => (
-                  <div
-                    key={item.text}
-                    className="flex items-center gap-2 rounded-[10px] bg-[color:color-mix(in_srgb,var(--surface-interactive-hover-background)_58%,transparent)] px-2.5 py-1.5"
-                  >
-                    <TourItemIcon name={item.icon} />
-                    <span className="text-[12px] leading-5 text-(--text-muted)">{item.text}</span>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <div className="mt-3.5 flex items-center justify-between gap-3">
-              <span className="text-[11px] font-medium tabular-nums text-(--text-muted)">
-                {step_index + 1} / {tour.steps.length}
-              </span>
-              <div className="flex items-center gap-2">
-                <button
-                  className="rounded-full border border-(--divider-subtle-color) px-3 py-1.5 text-[11px] font-medium text-(--text-default) transition-[background,color,transform] duration-(--motion-duration-fast) hover:-translate-y-[1px] hover:bg-(--surface-interactive-hover-background) disabled:pointer-events-none disabled:opacity-(--disabled-opacity)"
-                  disabled={step_index === 0}
-                  onClick={on_previous}
-                  type="button"
-                >
-                  {t("common.back")}
-                </button>
-                <button
-                  className="rounded-full bg-(--primary) px-3 py-1.5 text-[11px] font-medium text-white transition-[transform,opacity] duration-(--motion-duration-fast) hover:-translate-y-[1px] hover:opacity-92"
-                  onClick={is_last_step ? () => on_close({ completed: true }) : on_next}
-                  type="button"
-                >
-                  {is_last_step ? t("common.finish") : t("common.next")}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-
-  return createPortal(overlay, document.body);
 }
 
 export function OnboardingTourProvider({ children }: { children: ReactNode }) {
@@ -659,22 +235,16 @@ export function OnboardingTourProvider({ children }: { children: ReactNode }) {
     <ONBOARDING_TOUR_CONTEXT.Provider value={context_value}>
       {children}
       {active_tour_definition && active_tour ? (
-        <OnboardingTourOverlay
-          on_close={close_tour}
-          on_next={next_step}
-          on_previous={previous_step}
-          step_index={active_tour.step_index}
-          tour={active_tour_definition}
-        />
+        <Suspense fallback={null}>
+          <OnboardingTourOverlay
+            on_close={close_tour}
+            on_next={next_step}
+            on_previous={previous_step}
+            step_index={active_tour.step_index}
+            tour={active_tour_definition}
+          />
+        </Suspense>
       ) : null}
     </ONBOARDING_TOUR_CONTEXT.Provider>
   );
-}
-
-function TourItemIcon({ name }: { name: OnboardingTourStepItem["icon"] }) {
-  const className = "h-3.5 w-3.5 shrink-0 text-(--icon-muted)";
-  if (name === "bot") return <Bot className={className} />;
-  if (name === "users") return <Users2 className={className} />;
-  if (name === "hash") return <Hash className={className} />;
-  return <Puzzle className={className} />;
 }


### PR DESCRIPTION
## Summary
- Lazy-load the protected app session root and app layout so the web shell does not preload protected app code on initial entry.
- Split onboarding tour overlay UI out of the provider and load it only when a guide is shown.
- Move the lightweight class-name helper away from the heavier utility module so startup paths do not pull unrelated utilities.
- Update CHANGELOG for the startup preload reduction.

## Impact
This preserves normal app routing and onboarding behavior while reducing first-entry preload pressure for issue #144.

Fixes #144

## Validation
- make check
- pnpm --dir web run build
- Playwright smoke against Vite preview and the Go web server for /, /app, /settings, desktop deep links, and onboarding guide overlay