### PR TITLE
fix: #151 #152 DingTalk callback retries and token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Opened the channel capability UI for every ready IM channel instead of keeping Telegram, Discord, DingTalk, and WeChat Work hidden behind a frontend allowlist.
+- Deduplicated concurrent DingTalk access-token refreshes and acknowledged Stream callback failures after notifying users through `sessionWebhook`.
 - Updated IM channel copy so the iLink channel is displayed as WeChat in the UI and the WeChat Work setup guide follows the Bot ID + Secret intelligent bot flow.
 - Unified IM ingress handler responses so every channel returns a successful pairing-required acknowledgement instead of a generic client error when an external target still needs approval.
 - Stopped Telegram, Discord, DingTalk Stream, and WeChat polling ingress from sending external failure replies when a message only needs IM pairing approval.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.50.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.36.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.46.1
@@ -37,7 +38,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	modernc.org/libc v1.68.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/service/channels/channel_dingtalk.go
+++ b/internal/service/channels/channel_dingtalk.go
@@ -15,6 +15,7 @@ import (
 	channelmessage "github.com/nexus-research-lab/nexus/internal/service/channels/message"
 	dingchatbot "github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
 	dingclient "github.com/open-dingtalk/dingtalk-stream-sdk-go/client"
+	"golang.org/x/sync/singleflight"
 )
 
 type dingTalkChannel struct {
@@ -31,6 +32,7 @@ type dingTalkChannel struct {
 	accessToken    string
 	tokenExpiresAt time.Time
 	stream         *dingclient.StreamClient
+	tokenFlight    singleflight.Group
 }
 
 type dingTalkAccessTokenEnvelope struct {
@@ -149,6 +151,25 @@ func (c *dingTalkChannel) accessTokenForDelivery(ctx context.Context) (string, e
 		return "", fmt.Errorf("dingtalk channel is not configured")
 	}
 	now := time.Now()
+	c.mu.RLock()
+	if c.accessToken != "" && now.Before(c.tokenExpiresAt) {
+		token := c.accessToken
+		c.mu.RUnlock()
+		return token, nil
+	}
+	c.mu.RUnlock()
+
+	result, err, _ := c.tokenFlight.Do("refresh", func() (any, error) {
+		return c.refreshAccessToken(ctx, now)
+	})
+	if err != nil {
+		return "", err
+	}
+	return result.(string), nil
+}
+
+func (c *dingTalkChannel) refreshAccessToken(ctx context.Context, now time.Time) (string, error) {
+	// singleflight 获胜方在真正刷新前再检查一次，避免等待期间已有 goroutine 写入新 token。
 	c.mu.RLock()
 	if c.accessToken != "" && now.Before(c.tokenExpiresAt) {
 		token := c.accessToken
@@ -327,7 +348,9 @@ func (c *dingTalkChannel) handleStreamMessage(ctx context.Context, data *dingcha
 			return []byte(""), nil
 		}
 		if strings.TrimSpace(data.SessionWebhook) != "" {
-			_ = c.sendSessionWebhookText(ctx, data.SessionWebhook, "DingTalk 消息处理失败: "+truncateChannelError(err))
+			if notifyErr := c.sendSessionWebhookText(ctx, data.SessionWebhook, "DingTalk 消息处理失败: "+truncateChannelError(err)); notifyErr == nil {
+				return []byte(""), nil
+			}
 		}
 		return nil, err
 	}

--- a/internal/service/channels/router_test.go
+++ b/internal/service/channels/router_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1030,6 +1032,119 @@ func TestDingTalkChannelSendDeliveryMessage(t *testing.T) {
 	}
 	if msgParam["content"] != "今日新闻摘要" {
 		t.Fatalf("钉钉消息正文不正确: %+v", msgParam)
+	}
+}
+
+func TestDingTalkChannelAccessTokenRefreshUsesSingleflight(t *testing.T) {
+	var callers int32
+	var tokenRequests int32
+	releaseTokenResponse := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/v1.0/oauth2/accessToken" {
+			return nil, fmt.Errorf("未知钉钉请求路径: %s", request.URL.Path)
+		}
+		atomic.AddInt32(&tokenRequests, 1)
+		<-releaseTokenResponse
+		return jsonResponse(`{"accessToken":"ding-token","expireIn":7200}`), nil
+	})}
+	channel := newDingTalkChannel("ding-client", "ding-secret", "robot-code", client)
+	channel.baseURL = "https://dingtalk.test"
+
+	const concurrency = 12
+	start := make(chan struct{})
+	errs := make(chan error, concurrency)
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			atomic.AddInt32(&callers, 1)
+			token, err := channel.accessTokenForDelivery(context.Background())
+			if err != nil {
+				errs <- err
+				return
+			}
+			if token != "ding-token" {
+				errs <- fmt.Errorf("钉钉 token 不正确: %q", token)
+			}
+		}()
+	}
+
+	close(start)
+	deadline := time.After(time.Second)
+	for atomic.LoadInt32(&callers) < concurrency {
+		select {
+		case <-deadline:
+			close(releaseTokenResponse)
+			t.Fatalf("等待并发 token 请求进入调用路径超时，实际: %d", atomic.LoadInt32(&callers))
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	close(releaseTokenResponse)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("钉钉 token 刷新失败: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&tokenRequests); got != 1 {
+		t.Fatalf("并发刷新应只发起 1 次 token 请求，实际: %d", got)
+	}
+}
+
+func TestDingTalkStreamMessageAcknowledgesWhenWebhookReportsIngressFailure(t *testing.T) {
+	var webhookRequests int32
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() != "https://dingtalk.test/session-webhook" {
+			return nil, fmt.Errorf("未知钉钉请求地址: %s", request.URL.String())
+		}
+		atomic.AddInt32(&webhookRequests, 1)
+		var payload struct {
+			MsgType string `json:"msgtype"`
+			Text    struct {
+				Content string `json:"content"`
+			} `json:"text"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			return nil, fmt.Errorf("解析钉钉 webhook 请求失败: %w", err)
+		}
+		if payload.MsgType != "text" || !strings.Contains(payload.Text.Content, "DingTalk 消息处理失败") {
+			return nil, fmt.Errorf("钉钉 webhook 错误提示不正确: %+v", payload)
+		}
+		return jsonResponse(`{}`), nil
+	})}
+	channel := newDingTalkChannel("ding-client", "ding-secret", "", client)
+	ingress := &recordingIngressAcceptor{err: errors.New("dm temporarily unavailable")}
+	channel.SetIngress(ingress)
+
+	response, err := channel.handleStreamMessage(context.Background(), &dingchatbot.BotCallbackDataModel{
+		ConversationId:    "cid-group-1",
+		ConversationType:  "2",
+		ConversationTitle: "日报群",
+		ChatbotCorpId:     "corp-1",
+		MsgId:             "ding-message-1",
+		SenderStaffId:     "staff-1",
+		SenderNick:        "Alice",
+		SessionWebhook:    "https://dingtalk.test/session-webhook",
+		Text: dingchatbot.BotCallbackDataTextModel{
+			Content: "检查今天日报",
+		},
+	})
+	if err != nil {
+		t.Fatalf("已通过 webhook 通知用户时不应向钉钉返回错误: %v", err)
+	}
+	if response == nil || string(response) != "" {
+		t.Fatalf("钉钉 stream 应返回空 ACK: %q", string(response))
+	}
+	if len(ingress.requests) != 1 {
+		t.Fatalf("钉钉 Stream 消息应先进入 ingress: %+v", ingress.requests)
+	}
+	if got := atomic.LoadInt32(&webhookRequests); got != 1 {
+		t.Fatalf("钉钉错误 webhook 请求次数不正确: %d", got)
 	}
 }
 


### PR DESCRIPTION
## Changes

Fixes nexus-research-lab/nexus#151
Fixes nexus-research-lab/nexus#152

- Added `singleflight.Group` around DingTalk access-token refresh with a second cache check inside the winning refresh path.
- Changed DingTalk Stream callback handling so `ingress.Accept` failures return an empty ACK after `sessionWebhook` error notification succeeds, avoiding SDK InternalError responses and DingTalk retries.
- Kept the no-webhook and webhook-send-failed paths returning the original error so DingTalk can still retry when the user was not notified.
- Added regression coverage for concurrent token refresh and webhook ACK behavior, and updated the changelog.

Note: the old WeChat Work access-token file referenced in #152 no longer exists on current `main`; WeChat Work now uses the long-connection bot implementation, so this PR fixes the remaining applicable DingTalk path.

## Verification

- `go test ./internal/service/channels -run TestDingTalk`
- `make check-backend`
- `make check`