### PR TITLE
fix: #158 多账号个人微信通道 Start 部分失败时已启动账号未停止（goroutine 泄漏）

### DIFF
--- a/internal/service/channels/channel_weixin_personal_multi.go
+++ b/internal/service/channels/channel_weixin_personal_multi.go
@@ -34,10 +34,15 @@ func (c *personalWeixinMultiAccountChannel) ChannelType() string {
 }
 
 func (c *personalWeixinMultiAccountChannel) Start(ctx context.Context) error {
+	started := make([]*personalWeixinChannel, 0, len(c.accounts))
 	for _, account := range c.snapshotAccounts() {
 		if err := account.Start(ctx); err != nil {
+			for _, s := range started {
+				_ = s.Stop(ctx)
+			}
 			return err
 		}
+		started = append(started, account)
 	}
 	return nil
 }


### PR DESCRIPTION
## Fix for #158

### 问题
`personalWeixinMultiAccountChannel.Start()` 在逐个启动多个账号时，如果第 N 个账号 `Start` 失败，前面已启动的账号不会被 `Stop`，导致 goroutine 和 HTTP 长轮询连接泄漏。

### 修复
在 `Start` 返回错误前，逐一 `Stop` 已成功启动的账号。

### 测试
```bash
go build ./internal/service/channels/  # ✅
go test ./internal/service/channels/ -count=1  # ✅
```

Closes #158