### PR TITLE
fix: #160 Ingress 成功路径 finishIngressMessage 缺少 AccountID，多账号消息永远停留在 processing 状态

### DIFF
--- a/internal/service/channels/ingress.go
+++ b/internal/service/channels/ingress.go
@@ -265,6 +265,7 @@ func (s *IngressService) Accept(ctx context.Context, request IngressRequest) (*I
 		if err = s.control.finishIngressMessage(ctx, ingressMessageFinishInput{
 			OwnerUserID: normalized.ownerUserID,
 			Channel:     normalized.channelStored,
+			AccountID:   normalized.accountID,
 			ReqID:       normalized.reqID,
 			Status:      ingressMessageStatusAccepted,
 		}); err != nil {


### PR DESCRIPTION
## Fix for #160

### 问题
`ingress.go` 的 `Accept` 方法中，消息成功处理后的 `finishIngressMessage` 调用缺少 `AccountID` 字段，导致带 `account_id` 的入口消息（多账号个人微信场景）成功处理后无法从 `processing` 迁移到 `accepted`。

### 修复
在成功路径补上 `AccountID: normalized.accountID`（与失败路径一致）。

### 测试
```bash
go build ./internal/service/channels/  # ✅
go test ./internal/service/channels/ -count=1  # ✅
```

Closes #160