### PR TITLE
fix: #162 config.mustInt 在解析失败时对所有字段统一回退到 8010（端口默认值）

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,7 +111,7 @@ func Load() Config {
 	}
 	return Config{
 		Host:                           getEnv("HOST", "0.0.0.0"),
-		Port:                           mustInt(getEnv("PORT", "8010")),
+		Port:                           parseIntEnv(getEnv("PORT", "8010"), 8010),
 		Debug:                          debug,
 		ProjectName:                    getEnv("PROJECT_NAME", "nexus"),
 		LogLevel:                       logLevel,
@@ -121,9 +121,9 @@ func Load() Config {
 		LogNoColor:                     mustBool(getEnv("LOG_NO_COLOR", "false")),
 		LogFileEnabled:                 mustBool(getEnv("LOG_FILE_ENABLED", "true")),
 		LogRotateDaily:                 mustBool(getEnv("LOG_ROTATE_DAILY", "true")),
-		LogMaxSizeMB:                   mustInt(getEnv("LOG_MAX_SIZE_MB", "10")),
-		LogMaxAgeDays:                  mustInt(getEnv("LOG_MAX_AGE_DAYS", "7")),
-		LogMaxBackups:                  mustInt(getEnv("LOG_MAX_BACKUPS", "7")),
+		LogMaxSizeMB:                   parseIntEnv(getEnv("LOG_MAX_SIZE_MB", "10"), 10),
+		LogMaxAgeDays:                  parseIntEnv(getEnv("LOG_MAX_AGE_DAYS", "7"), 7),
+		LogMaxBackups:                  parseIntEnv(getEnv("LOG_MAX_BACKUPS", "7"), 7),
 		LogCompress:                    mustBool(getEnv("LOG_COMPRESS", "true")),
 		MessageDebugStreamEvent:        mustBool(getEnv("MESSAGE_DEBUG_STREAM_EVENT", "false")),
 		APIPrefix:                      getEnv("API_PREFIX", "/nexus/v1"),
@@ -138,20 +138,20 @@ func Load() Config {
 		SkillsAPIURL:                   getEnv("SKILLS_API_URL", "https://skills.sh"),
 		SkillsSourceURLs:               getEnv("SKILLS_SOURCE_URLS", ""),
 		SkillsDefaultSourcesEnabled:    mustBool(getEnv("SKILLS_DEFAULT_SOURCES_ENABLED", "true")),
-		SkillsAPISearchLimit:           mustInt(getEnv("SKILLS_API_SEARCH_LIMIT", "20")),
+		SkillsAPISearchLimit:           parseIntEnv(getEnv("SKILLS_API_SEARCH_LIMIT", "20"), 20),
 		DatabaseDriver:                 getEnv("DATABASE_DRIVER", "sqlite"),
 		DatabaseURL:                    getEnv("DATABASE_URL", "~/.nexus/data/nexus.db"),
 		AccessToken:                    getEnv("ACCESS_TOKEN", ""),
 		AuthSessionCookieName:          getEnv("AUTH_SESSION_COOKIE_NAME", "nexus_session"),
 		AuthCookieSameSite:             getEnv("AUTH_COOKIE_SAMESITE", "lax"),
 		AuthCookieSecure:               mustBool(getEnv("AUTH_COOKIE_SECURE", "false")),
-		AuthSessionTTLHours:            mustInt(getEnv("AUTH_SESSION_TTL_HOURS", "24")),
+		AuthSessionTTLHours:            parseIntEnv(getEnv("AUTH_SESSION_TTL_HOURS", "24"), 24),
 		BaseSystemPrompt:               getEnv("BASE_SYSTEM_PROMPT", ""),
 		MainAgentSystemPrompt:          getEnv("MAIN_AGENT_SYSTEM_PROMPT", ""),
 		MemoryEnabled:                  mustBool(getEnv("MEMORY_ENABLED", "true")),
 		MemoryAutoRecall:               mustBool(getEnv("MEMORY_AUTO_RECALL", "true")),
 		MemoryAutoExtract:              mustBool(getEnv("MEMORY_AUTO_EXTRACT", "true")),
-		MemoryMaxResults:               mustInt(getEnv("MEMORY_MAX_RESULTS", "5")),
+		MemoryMaxResults:               parseIntEnv(getEnv("MEMORY_MAX_RESULTS", "5"), 5),
 		MemoryScoreThreshold:           mustFloat(getEnv("MEMORY_SCORE_THRESHOLD", "0.08")),
 		DiscordEnabled:                 mustBool(getEnv("DISCORD_ENABLED", "true")),
 		DiscordBotToken:                getEnv("DISCORD_BOT_TOKEN", ""),
@@ -160,14 +160,14 @@ func Load() Config {
 		ConnectorOAuthRedirectURI:      getEnv("CONNECTOR_OAUTH_REDIRECT_URI", "http://localhost:3000/capability/connectors/oauth/callback"),
 		ConnectorOAuthAllowedOrigins:   mustStringList(getEnv("CONNECTOR_OAUTH_ALLOWED_ORIGINS", "http://localhost:3000")),
 		AllowedWebSocketOrigins:        mustStringList(getEnv("ALLOWED_WEBSOCKET_ORIGINS", "")),
-		ConnectorOAuthStateTTLSeconds:  mustInt(getEnv("CONNECTOR_OAUTH_STATE_TTL_SECONDS", "600")),
+		ConnectorOAuthStateTTLSeconds:  parseIntEnv(getEnv("CONNECTOR_OAUTH_STATE_TTL_SECONDS", "600"), 600),
 		GoalEnabled:                    mustBool(getEnv("NEXUS_GOAL_ENABLED", "true")),
 		GoalAutoContinueEnabled:        mustBool(getEnv("NEXUS_GOAL_AUTO_CONTINUE_ENABLED", "true")),
-		GoalMaxContinuationsPerRun:     mustInt(getEnv("NEXUS_GOAL_MAX_CONTINUATIONS_PER_RUN", "20")),
-		AutomationRunTimeoutSeconds:    mustInt(getEnv("AUTOMATION_RUN_TIMEOUT_SECONDS", "21600")),
-		RuntimeRoundIdleTimeoutSeconds: mustInt(getEnv("RUNTIME_ROUND_IDLE_TIMEOUT_SECONDS", "1200")),
-		RuntimeIdleSessionTTLSeconds:   mustInt(getEnv("RUNTIME_IDLE_SESSION_TTL_SECONDS", "600")),
-		RuntimeIdleSessionSweepSeconds: mustInt(getEnv("RUNTIME_IDLE_SESSION_SWEEP_SECONDS", "120")),
+		GoalMaxContinuationsPerRun:     parseIntEnv(getEnv("NEXUS_GOAL_MAX_CONTINUATIONS_PER_RUN", "20"), 20),
+		AutomationRunTimeoutSeconds:    parseIntEnv(getEnv("AUTOMATION_RUN_TIMEOUT_SECONDS", "21600"), 21600),
+		RuntimeRoundIdleTimeoutSeconds: parseIntEnv(getEnv("RUNTIME_ROUND_IDLE_TIMEOUT_SECONDS", "1200"), 1200),
+		RuntimeIdleSessionTTLSeconds:   parseIntEnv(getEnv("RUNTIME_IDLE_SESSION_TTL_SECONDS", "600"), 600),
+		RuntimeIdleSessionSweepSeconds: parseIntEnv(getEnv("RUNTIME_IDLE_SESSION_SWEEP_SECONDS", "120"), 120),
 		ConnectorCredentialsKey:        getEnv("CONNECTOR_CREDENTIALS_KEY", ""),
 		ConnectorGitHubClientID:        getEnv("CONNECTOR_GITHUB_CLIENT_ID", ""),
 		ConnectorGitHubClientSecret:    getEnv("CONNECTOR_GITHUB_CLIENT_SECRET", ""),
@@ -215,10 +215,10 @@ func getEnv(key string, fallback string) string {
 	return fallback
 }
 
-func mustInt(raw string) int {
+func parseIntEnv(raw string, fallback int) int {
 	value, err := strconv.Atoi(raw)
 	if err != nil {
-		return 8010
+		return fallback
 	}
 	return value
 }

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -1,0 +1,104 @@
+package config
+
+import "testing"
+
+func TestParseIntEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		fallback int
+		want     int
+	}{
+		{"valid int", "42", 0, 42},
+		{"valid zero", "0", 99, 0},
+		{"valid negative", "-1", 0, -1},
+		{"invalid string returns fallback", "abc", 10, 10},
+		{"empty string returns fallback", "", 24, 24},
+		{"float string returns fallback", "3.14", 7, 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseIntEnv(tt.raw, tt.fallback)
+			if got != tt.want {
+				t.Errorf("parseIntEnv(%q, %d) = %d, want %d", tt.raw, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustBool(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"true", "true", true},
+		{"false", "false", false},
+		{"1", "1", true},
+		{"0", "0", false},
+		{"invalid returns false", "yes", false},
+		{"empty returns false", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mustBool(tt.raw)
+			if got != tt.want {
+				t.Errorf("mustBool(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustFloat(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want float64
+	}{
+		{"valid float", "3.14", 3.14},
+		{"valid int as float", "42", 42.0},
+		{"zero", "0", 0},
+		{"invalid returns zero", "abc", 0},
+		{"empty returns zero", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mustFloat(tt.raw)
+			if got != tt.want {
+				t.Errorf("mustFloat(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustStringList(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"single", "a", []string{"a"}},
+		{"multiple", "a, b, c", []string{"a", "b", "c"}},
+		{"with empty parts", "a, , b", []string{"a", "b"}},
+		{"empty string", "", []string{}},
+		{"only spaces", "  ,  ", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mustStringList(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Errorf("mustStringList(%q) = %v, want %v", tt.raw, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("mustStringList(%q)[%d] = %q, want %q", tt.raw, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Fix for #162

### 问题
`mustInt` 在 `strconv.Atoi` 失败时统一返回 `8010`（端口默认值），导致 13 个配置字段在解析失败时使用了错误的 fallback。

### 修复
- 将 `mustInt(raw string) int` 改为 `parseIntEnv(raw string, fallback int) int`，每个字段传入各自的正确默认值
- 补充 `parseIntEnv`、`mustBool`、`mustFloat`、`mustStringList` 的单元测试

### 测试
```bash
go test ./internal/config/ -v -count=1  # 全部通过
```

Closes #162