### PR TITLE
fix: #165 Resolve data race in commitMemoryTurn vs refreshSessionMetaAfterRoundFinished

### DIFF
--- a/internal/service/dm/service_memory.go
+++ b/internal/service/dm/service_memory.go
@@ -68,7 +68,7 @@ func (s *Service) appendRuntimeUserContext(
 	return runtimeContent.AppendText(s.agents.BuildRuntimeUserMessageSuffixForContext(ctx, agentValue, "dm:"+strings.TrimSpace(sessionKey)))
 }
 
-func (r *roundRunner) commitMemoryTurn() {
+func (r *roundRunner) commitMemoryTurn(sessionID string) {
 	if r == nil || r.agent == nil {
 		return
 	}
@@ -82,12 +82,12 @@ func (r *roundRunner) commitMemoryTurn() {
 		UserID:     r.ownerUserID,
 		AgentID:    r.agent.AgentID,
 		SessionKey: r.sessionKey,
-		SessionID:  sessionIDString(r.session),
+		SessionID:  sessionID,
 	}, memorysvc.CommittedTurn{
 		UserText:      r.content,
 		AssistantText: assistantText,
 		SessionKey:    r.sessionKey,
-		SessionID:     sessionIDString(r.session),
+		SessionID:     sessionID,
 		RoundID:       r.roundID,
 		AgentID:       r.agent.AgentID,
 	})

--- a/internal/service/dm/service_round.go
+++ b/internal/service/dm/service_round.go
@@ -112,7 +112,8 @@ func (r *roundRunner) run(ctx context.Context) {
 	r.recordGoalContinuationProgress(result)
 	if result.CompletedByAssistant {
 		r.recordTerminalAssistantUsage(finalAssistant)
-		go r.commitMemoryTurn()
+		sessionID := sessionIDString(r.session) // snapshot before goroutine to avoid data race
+		go r.commitMemoryTurn(sessionID)
 	}
 	r.service.runtime.MarkRoundFinished(r.sessionKey, r.roundID)
 	r.refreshSessionMetaAfterRoundFinished()


### PR DESCRIPTION
## Summary

Fixes #165

### Problem

`go test -race` in `internal/service/dm` reliably reports a data race:

- **Goroutine A** (`commitMemoryTurn`): reads `r.session` via `sessionIDString(r.session)`
- **Goroutine B** (main): writes `r.session = *updated` in `refreshSessionMetaAfterRoundFinished`

These run concurrently because `run()` launches `go r.commitMemoryTurn()` immediately before calling `r.refreshSessionMetaAfterRoundFinished()`.

### Fix (方案 A from issue)

Snapshot the session ID **before** launching the goroutine and pass it through as a parameter:

```go
// before
go r.commitMemoryTurn()

// after
sessionID := sessionIDString(r.session)
go r.commitMemoryTurn(sessionID)
```

`commitMemoryTurn` only needs the session ID string — it doesn't depend on post-refresh session state.

### Changes
- `internal/service/dm/service_memory.go`: `commitMemoryTurn` now takes `sessionID string` param instead of reading `r.session`
- `internal/service/dm/service_round.go`: snapshot `sessionIDString(r.session)` before `go` statement

### Testing
- `go build ./...` ✅
- `go vet ./internal/service/dm/...` ✅
- `go test -race -run TestHandleChatSchedulesTitleForExistingExternalIMDefaultTitle ./internal/service/dm/...` ✅ (previously failed with data race)
- `go test -race ./internal/service/dm/...` ✅ (full package, all pass)