### PR TITLE
fix: #167 SystemMessageMetadata.error_status should include number

### DIFF
--- a/web/src/types/conversation/message.ts
+++ b/web/src/types/conversation/message.ts
@@ -206,7 +206,7 @@ export interface SystemMessageMetadata extends Record<string, any> {
   attempt?: number;
   max_retries?: number;
   retry_delay_ms?: number;
-  error_status?: string | null;
+  error_status?: string | number | null;
   error?: string | null;
 }
 


### PR DESCRIPTION
## Summary

Fixes #167

Backend's `normalizeAPIRetryMetadata` sets `error_status` as an integer via `setAPIRetryInt`, but the TypeScript type for `SystemMessageMetadata.error_status` only allowed `string | null`.

This changes it to `string | number | null` to match the existing `SystemEventContent.error_status` definition (line 101).

## Changes
- `web/src/types/conversation/message.ts`: `error_status` type updated from `string | null` to `string | number | null`

## Testing
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run build` ✅

No runtime impact — TypeScript types are erased at runtime. This only improves type safety and correctness.