### PR TITLE
fix: #173 TestRealtimeServiceAllowsReciprocalPublicMentionChain flaky TempDir cleanup

### DIFF
--- a/internal/service/room/service_realtime_mentions_test.go
+++ b/internal/service/room/service_realtime_mentions_test.go
@@ -175,6 +175,27 @@ func TestRealtimeServiceAllowsReciprocalPublicMentionChain(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Devin @Amy 后未继续触发 Amy")
 	}
+	// Wait for background room_mention rounds to finish before TempDir cleanup.
+	// The reciprocal chain produces multiple mention rounds; drain events
+	// until the channel is idle (no new events for 500ms), ensuring all
+	// overlay writes complete. This prevents the flaky "directory not empty"
+	// error under -race.
+	idleTimeout := 500 * time.Millisecond
+	timer := time.NewTimer(idleTimeout)
+	for {
+		select {
+		case <-sender.events:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(idleTimeout)
+		case <-timer.C:
+			return
+		}
+	}
 }
 
 func TestRealtimeServiceQueuesPublicMentionWhenTargetRunning(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #173

`TestRealtimeServiceAllowsReciprocalPublicMentionChain` was a flaky test (~40% failure under `-race`), failing on TempDir cleanup with "directory not empty" because background goroutines from room_mention rounds were still writing overlay files when the test exited.

## Root Cause

This is the **missed case of #103** (commit ca38ac1f). The fix in #103 added `collectRoomEventsUntil(..., finished)` to two other tests but omitted this one. The reciprocal chain test has multiple room_mention rounds, and the test returned immediately upon receiving `amySecondPrompt` without waiting for the final rounds to complete.

## Changes

After the select block, drain the events channel with a **500ms idle timeout**: keep consuming events as long as they arrive, and only exit when the channel has been quiet for 500ms. This ensures all background goroutines (overlay writes, session cleanup) complete before TempDir cleanup runs.

## Testing

```bash
go test -race -count=5 -run TestRealtimeServiceAllowsReciprocalPublicMentionChain ./internal/service/room/
```

All 5 iterations pass. Full room package test suite also passes:
```bash
go test -race ./internal/service/room/
```

## Why idle-timeout drain instead of collectRoomEventsUntil?

The reciprocal chain produces **multiple** room_mention rounds. A single `collectRoomEventsUntil` for `room_mention_* finished` would catch the first finished round but miss subsequent ones. The idle-timeout approach robustly handles any number of rounds.