### PR TITLE
fix: #175 RunningSubagents 字段存在 data race — dispatchPostRoundWork 读取未加锁

### DIFF
--- a/internal/service/room/execution_round.go
+++ b/internal/service/room/execution_round.go
@@ -33,7 +33,7 @@ func (s *RealtimeService) runRound(
 	}
 	waitGroup.Wait()
 
-	roundValue.RunningSubagents = roundValue.hasRunningSubagentTasks()
+	roundValue.RunningSubagents.Store(roundValue.hasRunningSubagentTasks())
 	s.finishRound(roundValue)
 
 	finalStatus := "finished"
@@ -52,7 +52,7 @@ func (s *RealtimeService) runRound(
 		mapTerminalSubtype(finalStatus),
 	))
 	s.broadcastSessionStatus(ctx, roundValue.SessionKey)
-	if roundValue.RunningSubagents {
+	if roundValue.RunningSubagents.Load() {
 		s.startIdleSubagentNotificationDrains(contextWithQueueOwner(context.Background(), roundValue.OwnerUserID), roundValue)
 	}
 	if finalStatus == "finished" {

--- a/internal/service/room/goal_continuation.go
+++ b/internal/service/room/goal_continuation.go
@@ -165,7 +165,7 @@ func (s *RealtimeService) dispatchPostRoundWork(ctx context.Context, roundValue 
 	if roundValue == nil {
 		return
 	}
-	if roundValue.RunningSubagents {
+	if roundValue.RunningSubagents.Load() {
 		return
 	}
 	if s.ShouldDeferGoalContinuation(ctx, roundValue.SessionKey) {

--- a/internal/service/room/goal_continuation_test.go
+++ b/internal/service/room/goal_continuation_test.go
@@ -198,20 +198,20 @@ func TestRealtimeServiceReleasesSubagentWaitAndPlansRoomGoalContinuation(t *test
 		goals: goalProvider,
 	}
 	roundValue := &activeRoomRound{
-		SessionKey:       "room:group:conversation-1",
-		ConversationID:   "conversation-1",
-		RoundID:          "round-1",
-		RunningSubagents: true,
+		SessionKey:     "room:group:conversation-1",
+		ConversationID: "conversation-1",
+		RoundID:        "round-1",
 		Slots: map[string]*activeRoomSlot{
 			"agent-1": {AgentID: "agent-1"},
 		},
 	}
+	roundValue.RunningSubagents.Store(true)
 
 	service.releaseRoundSubagentWait(roundValue)
 
 	goalProvider.mu.Lock()
 	defer goalProvider.mu.Unlock()
-	if roundValue.RunningSubagents {
+	if roundValue.RunningSubagents.Load() {
 		t.Fatal("RunningSubagents = true, want released after all subagent tasks finish")
 	}
 	if goalProvider.planCalls != 1 {

--- a/internal/service/room/round_state.go
+++ b/internal/service/room/round_state.go
@@ -3,6 +3,7 @@ package room
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	sdkpermission "github.com/nexus-research-lab/nexus-agent-sdk-bridge/permission"
@@ -77,7 +78,7 @@ type activeRoomRound struct {
 	GoalContext       string
 	Slots             map[string]*activeRoomSlot
 	PublicMentions    []publicMentionWake
-	RunningSubagents  bool
+	RunningSubagents  atomic.Bool
 	Done              chan struct{}
 	doneOnce          sync.Once
 }

--- a/internal/service/room/subagent_idle_drain.go
+++ b/internal/service/room/subagent_idle_drain.go
@@ -136,8 +136,8 @@ func (s *RealtimeService) releaseRoundSubagentWait(roundValue *activeRoomRound) 
 	}
 	shouldDispatch := false
 	s.mu.Lock()
-	if roundValue.RunningSubagents && !roundValue.hasRunningSubagentTasks() {
-		roundValue.RunningSubagents = false
+	if roundValue.RunningSubagents.Load() && !roundValue.hasRunningSubagentTasks() {
+		roundValue.RunningSubagents.Store(false)
 		shouldDispatch = true
 	}
 	s.mu.Unlock()


### PR DESCRIPTION
## Summary

Fixes #175

`RunningSubagents` was a plain `bool` field accessed from multiple goroutines with inconsistent locking. `dispatchPostRoundWork` (launched via `go` in `execution_round.go:61`) read the field without `s.mu`, while `releaseRoundSubagentWait` wrote it under `s.mu` — a formal data race per the Go memory model.

## Changes

Replaced `RunningSubagents bool` with `sync/atomic.Bool` (Method A from the issue):

| File | Change |
|---|---|
| `round_state.go` | `RunningSubagents bool` → `atomic.Bool` |
| `execution_round.go` | `= ...` → `Store(...)`, `if x` → `if x.Load()` |
| `goal_continuation.go` | `if x` → `if x.Load()` |
| `subagent_idle_drain.go` | `x = false` → `x.Store(false)`, `if x` → `if x.Load()` |
| `goal_continuation_test.go` | struct literal updated to use `Store(true)` |

## Testing

```bash
go test -race -count=1 -run "TestRealtimeService.*Goal" ./internal/service/room/ -v
```

All 7 goal continuation tests pass. The `s.mu` lock in `releaseRoundSubagentWait` is retained (still protects `hasRunningSubagentTasks()`); the `RunningSubagents.Store(false)` inside the lock is safe — atomic operations are safe under any lock.

## Why atomic.Bool over lock-based fix (Method B)?

- Zero additional lock contention on the hot path (`dispatchPostRoundWork`)
- `atomic.Bool` is purpose-built for this pattern
- Smaller diff, cleaner semantics

## Note

The pre-existing `TestRealtimeServiceAllowsReciprocalPublicMentionChain` flaky failure (#173) is **not** related to this change and is addressed separately in PR #174.