### PR TITLE
fix: #177 inferSubagentTaskProgressStatus 误判 incomplete/not completed 为 completed

### DIFF
--- a/internal/service/session/service_subagent_task.go
+++ b/internal/service/session/service_subagent_task.go
@@ -313,7 +313,14 @@ func inferSubagentTaskProgressStatus(text string) string {
 	if normalized == "" {
 		return ""
 	}
-	for _, marker := range []string{"completed", "complete", "finished", "done", "已完成", "完成"} {
+	// Check negation markers first to avoid false positives.
+	// e.g. "incomplete" contains "complete", "not completed" contains "completed".
+	for _, negMarker := range []string{"incomplete", "not completed", "not done", "not complete", "未完成"} {
+		if strings.Contains(normalized, negMarker) {
+			return ""
+		}
+	}
+	for _, marker := range []string{"completed", "finished", "done", "已完成", "完成"} {
 		if strings.Contains(normalized, marker) {
 			return "completed"
 		}

--- a/internal/service/session/service_subagent_task_test.go
+++ b/internal/service/session/service_subagent_task_test.go
@@ -99,6 +99,46 @@ func TestBuildSubagentTasksMergesTaskUpdatedTerminal(t *testing.T) {
 	}
 }
 
+func TestInferSubagentTaskProgressStatusEdgeCases(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Negation — must NOT be classified as completed
+		{"incomplete", ""},
+		{"not completed", ""},
+		{"not done", ""},
+		{"not complete", ""},
+		{"failed to complete", "failed"}, // "failed" takes priority after negation guard
+		{"task is incomplete", ""},
+		{"未完成", ""},
+		// Positive — should be classified correctly
+		{"completed successfully", "completed"},
+		{"finished", "completed"},
+		{"done", "completed"},
+		{"已完成", "completed"},
+		{"完成", "completed"},
+		// Failed
+		{"failed with error", "failed"},
+		{"error occurred", "failed"},
+		// Running
+		{"running", "running"},
+		{"in progress", "running"},
+		// Empty
+		{"", ""},
+		// Neutral text
+		{"reading files", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := inferSubagentTaskProgressStatus(tt.input)
+			if got != tt.want {
+				t.Errorf("inferSubagentTaskProgressStatus(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildSubagentTasksIncludesAssistantTaskProgress(t *testing.T) {
 	messages := []protocol.Message{
 		{


### PR DESCRIPTION
## Summary

Fixes #177

`inferSubagentTaskProgressStatus` used `strings.Contains` to match completion markers. Because `"complete"` is a substring of `"incomplete"` and `"completed"` is a substring of `"not completed"`, negation phrases were incorrectly classified as `"completed"`.

## Changes

- **Negation guard**: Before positive matching, check for negation markers (`incomplete`, `not completed`, `not done`, `not complete`, `未完成`). If found, return empty string.
- **Removed `"complete"` from positive markers**: `"completed"` already covers the positive case; `"complete"` alone was the primary false-positive source.
- **Added unit tests**: Table-driven test covering all edge cases from the issue (`incomplete`, `not completed`, `failed to complete`, positive cases, etc.)

## Testing

```bash
go test ./internal/service/session/ -run "TestInferSubagent|TestBuildSubagentTasks" -v
```

All tests pass. No regressions in existing subagent task tests.

## Approach

Used **Method A** from the issue (negation-first check). Chose this over regex (Method B) for simplicity and consistency with the existing code pattern.