### PR TITLE
fix: #182 redeploySkillToInstalledAgents 多 Agent 部署首个错误即中止

### DIFF
--- a/internal/service/skills/marketplace_external.go
+++ b/internal/service/skills/marketplace_external.go
@@ -151,3 +151,16 @@ type CheckSkillUpdatesResponse struct {
 	SkippedSkills   []string             `json:"skipped_skills"`
 	Failures        []SkillActionFailure `json:"failures"`
 }
+
+// RedeployAgentFailure 表示单个 Agent 的技能重新部署失败。
+type RedeployAgentFailure struct {
+	AgentID string `json:"agent_id"`
+	AgentName string `json:"agent_name"`
+	Error   string `json:"error"`
+}
+
+// RedeployResult 表示技能重新部署到多 Agent 的聚合结果。
+type RedeployResult struct {
+	SuccessAgents []string               `json:"success_agents"`
+	Failures      []RedeployAgentFailure `json:"failures"`
+}

--- a/internal/service/skills/marketplace_external.go
+++ b/internal/service/skills/marketplace_external.go
@@ -140,9 +140,10 @@ type SkillActionFailure struct {
 
 // UpdateInstalledSkillsResponse 表示批量更新结果。
 type UpdateInstalledSkillsResponse struct {
-	UpdatedSkills []string             `json:"updated_skills"`
-	SkippedSkills []string             `json:"skipped_skills"`
-	Failures      []SkillActionFailure `json:"failures"`
+	UpdatedSkills []string              `json:"updated_skills"`
+	SkippedSkills []string              `json:"skipped_skills"`
+	Failures      []SkillActionFailure  `json:"failures"`
+	DeployResults []SkillRedeployResult `json:"deploy_results,omitempty"`
 }
 
 // CheckSkillUpdatesResponse 表示批量检查更新结果。
@@ -152,15 +153,28 @@ type CheckSkillUpdatesResponse struct {
 	Failures        []SkillActionFailure `json:"failures"`
 }
 
+// RedeployAgentSuccess 表示单个 Agent 的技能重新部署成功。
+type RedeployAgentSuccess struct {
+	AgentID   string `json:"agent_id"`
+	AgentName string `json:"agent_name"`
+}
+
 // RedeployAgentFailure 表示单个 Agent 的技能重新部署失败。
 type RedeployAgentFailure struct {
-	AgentID string `json:"agent_id"`
+	AgentID   string `json:"agent_id"`
 	AgentName string `json:"agent_name"`
-	Error   string `json:"error"`
+	Error     string `json:"error"`
+}
+
+// SkillRedeployResult 表示单个技能重新部署到多个 Agent 的结果。
+type SkillRedeployResult struct {
+	SkillName     string                 `json:"skill_name"`
+	SuccessAgents []RedeployAgentSuccess `json:"success_agents"`
+	Failures      []RedeployAgentFailure `json:"failures"`
 }
 
 // RedeployResult 表示技能重新部署到多 Agent 的聚合结果。
 type RedeployResult struct {
-	SuccessAgents []string               `json:"success_agents"`
+	SuccessAgents []RedeployAgentSuccess `json:"success_agents"`
 	Failures      []RedeployAgentFailure `json:"failures"`
 }

--- a/internal/service/skills/marketplace_update.go
+++ b/internal/service/skills/marketplace_update.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"net/http"
@@ -82,11 +83,23 @@ func (s *Service) UpdateImportedSkills(ctx context.Context) (*UpdateInstalledSki
 			})
 			continue
 		}
-		if redeployErr := s.redeploySkillToInstalledAgents(ctx, detail.Name); redeployErr != nil {
+		if redeployResult, redeployErr := s.redeploySkillToInstalledAgents(ctx, detail.Name); redeployErr != nil {
 			result.Failures = append(result.Failures, SkillActionFailure{
 				SkillName: name,
 				Error:     redeployErr.Error(),
 			})
+			continue
+		} else if len(redeployResult.Failures) > 0 {
+			for _, f := range redeployResult.Failures {
+				result.Failures = append(result.Failures, SkillActionFailure{
+					SkillName: name,
+					Error:     fmt.Sprintf("agent %s (%s): %s", f.AgentName, f.AgentID, f.Error),
+				})
+			}
+			// Even if some agents failed, the skill was updated for successful ones
+			if len(redeployResult.SuccessAgents) > 0 {
+				result.UpdatedSkills = append(result.UpdatedSkills, name)
+			}
 			continue
 		}
 		result.UpdatedSkills = append(result.UpdatedSkills, name)
@@ -108,8 +121,14 @@ func (s *Service) UpdateSingleSkill(ctx context.Context, skillName string) (*Det
 	if err != nil {
 		return nil, err
 	}
-	if err = s.redeploySkillToInstalledAgents(ctx, detail.Name); err != nil {
+	redeployResult, err := s.redeploySkillToInstalledAgents(ctx, detail.Name)
+	if err != nil {
 		return nil, err
+	}
+	if len(redeployResult.Failures) > 0 {
+		// Return detail with a warning about partial failures.
+		// The caller can inspect Failures for details.
+		detail.DeployFailures = redeployResult.Failures
 	}
 	return detail, nil
 }

--- a/internal/service/skills/marketplace_update.go
+++ b/internal/service/skills/marketplace_update.go
@@ -68,6 +68,7 @@ func (s *Service) UpdateImportedSkills(ctx context.Context) (*UpdateInstalledSki
 		UpdatedSkills: make([]string, 0),
 		SkippedSkills: make([]string, 0),
 		Failures:      make([]SkillActionFailure, 0),
+		DeployResults: make([]SkillRedeployResult, 0),
 	}
 	names := slices.Sorted(maps.Keys(records))
 	for _, name := range names {
@@ -83,26 +84,30 @@ func (s *Service) UpdateImportedSkills(ctx context.Context) (*UpdateInstalledSki
 			})
 			continue
 		}
-		if redeployResult, redeployErr := s.redeploySkillToInstalledAgents(ctx, detail.Name); redeployErr != nil {
+		result.UpdatedSkills = append(result.UpdatedSkills, name)
+		redeployResult, redeployErr := s.redeploySkillToInstalledAgents(ctx, detail.Name)
+		if redeployErr != nil {
 			result.Failures = append(result.Failures, SkillActionFailure{
 				SkillName: name,
 				Error:     redeployErr.Error(),
 			})
 			continue
-		} else if len(redeployResult.Failures) > 0 {
+		}
+		if len(redeployResult.SuccessAgents) > 0 || len(redeployResult.Failures) > 0 {
+			result.DeployResults = append(result.DeployResults, SkillRedeployResult{
+				SkillName:     name,
+				SuccessAgents: redeployResult.SuccessAgents,
+				Failures:      redeployResult.Failures,
+			})
+		}
+		if len(redeployResult.Failures) > 0 {
 			for _, f := range redeployResult.Failures {
 				result.Failures = append(result.Failures, SkillActionFailure{
 					SkillName: name,
 					Error:     fmt.Sprintf("agent %s (%s): %s", f.AgentName, f.AgentID, f.Error),
 				})
 			}
-			// Even if some agents failed, the skill was updated for successful ones
-			if len(redeployResult.SuccessAgents) > 0 {
-				result.UpdatedSkills = append(result.UpdatedSkills, name)
-			}
-			continue
 		}
-		result.UpdatedSkills = append(result.UpdatedSkills, name)
 	}
 	return result, nil
 }
@@ -125,9 +130,8 @@ func (s *Service) UpdateSingleSkill(ctx context.Context, skillName string) (*Det
 	if err != nil {
 		return nil, err
 	}
+	detail.DeploySuccesses = redeployResult.SuccessAgents
 	if len(redeployResult.Failures) > 0 {
-		// Return detail with a warning about partial failures.
-		// The caller can inspect Failures for details.
 		detail.DeployFailures = redeployResult.Failures
 	}
 	return detail, nil

--- a/internal/service/skills/model_skill.go
+++ b/internal/service/skills/model_skill.go
@@ -62,8 +62,9 @@ type Info struct {
 // Detail 表示 skill 详情。
 type Detail struct {
 	Info
-	ReadmeMarkdown string `json:"readme_markdown"`
-	Recommendation string `json:"recommendation"`
+	ReadmeMarkdown string                 `json:"readme_markdown"`
+	Recommendation string                 `json:"recommendation"`
+	DeployFailures []RedeployAgentFailure `json:"deploy_failures,omitempty"`
 }
 
 // Query 表示技能查询参数。

--- a/internal/service/skills/model_skill.go
+++ b/internal/service/skills/model_skill.go
@@ -62,9 +62,10 @@ type Info struct {
 // Detail 表示 skill 详情。
 type Detail struct {
 	Info
-	ReadmeMarkdown string                 `json:"readme_markdown"`
-	Recommendation string                 `json:"recommendation"`
-	DeployFailures []RedeployAgentFailure `json:"deploy_failures,omitempty"`
+	ReadmeMarkdown  string                 `json:"readme_markdown"`
+	Recommendation  string                 `json:"recommendation"`
+	DeploySuccesses []RedeployAgentSuccess `json:"deploy_successes,omitempty"`
+	DeployFailures  []RedeployAgentFailure `json:"deploy_failures,omitempty"`
 }
 
 // Query 表示技能查询参数。

--- a/internal/service/skills/service_catalog.go
+++ b/internal/service/skills/service_catalog.go
@@ -108,7 +108,7 @@ func (s *Service) deploySkillToWorkspace(agentValue *protocol.Agent, record cata
 
 func (s *Service) redeploySkillToInstalledAgents(ctx context.Context, skillName string) (*RedeployResult, error) {
 	result := &RedeployResult{
-		SuccessAgents: make([]string, 0),
+		SuccessAgents: make([]RedeployAgentSuccess, 0),
 		Failures:      make([]RedeployAgentFailure, 0),
 	}
 	if s.agents == nil {
@@ -148,7 +148,10 @@ func (s *Service) redeploySkillToInstalledAgents(ctx context.Context, skillName 
 			})
 			continue
 		}
-		result.SuccessAgents = append(result.SuccessAgents, agentValue.AgentID)
+		result.SuccessAgents = append(result.SuccessAgents, RedeployAgentSuccess{
+			AgentID:   agentValue.AgentID,
+			AgentName: agentValue.Name,
+		})
 	}
 	return result, nil
 }

--- a/internal/service/skills/service_catalog.go
+++ b/internal/service/skills/service_catalog.go
@@ -106,36 +106,51 @@ func (s *Service) deploySkillToWorkspace(agentValue *protocol.Agent, record cata
 	return workspacesvc.DeploySkill(record.Detail.Name, record.SourcePath, agentValue.WorkspacePath, context)
 }
 
-func (s *Service) redeploySkillToInstalledAgents(ctx context.Context, skillName string) error {
+func (s *Service) redeploySkillToInstalledAgents(ctx context.Context, skillName string) (*RedeployResult, error) {
+	result := &RedeployResult{
+		SuccessAgents: make([]string, 0),
+		Failures:      make([]RedeployAgentFailure, 0),
+	}
 	if s.agents == nil {
-		return nil
+		return result, nil
 	}
 	records, err := s.loadCatalogRecords(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	record, ok := records[strings.TrimSpace(skillName)]
 	if !ok {
-		return errors.New("skill not found")
+		return nil, errors.New("skill not found")
 	}
 	agents, err := s.agents.ListAgentRecords(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for index := range agents {
 		agentValue := agents[index]
 		names, err := workspacesvc.ListDeployedSkills(agentValue.WorkspacePath)
 		if err != nil {
-			return err
+			result.Failures = append(result.Failures, RedeployAgentFailure{
+				AgentID:   agentValue.AgentID,
+				AgentName: agentValue.Name,
+				Error:     err.Error(),
+			})
+			continue
 		}
 		if !slices.Contains(names, record.Detail.Name) {
 			continue
 		}
 		if err = s.deploySkillToWorkspace(&agentValue, record); err != nil {
-			return err
+			result.Failures = append(result.Failures, RedeployAgentFailure{
+				AgentID:   agentValue.AgentID,
+				AgentName: agentValue.Name,
+				Error:     err.Error(),
+			})
+			continue
 		}
+		result.SuccessAgents = append(result.SuccessAgents, agentValue.AgentID)
 	}
-	return nil
+	return result, nil
 }
 
 func (s *Service) loadCatalogRecords(ctx context.Context) (map[string]catalogRecord, error) {

--- a/internal/service/skills/service_test.go
+++ b/internal/service/skills/service_test.go
@@ -252,7 +252,7 @@ skill body
 	}
 }
 
-func TestUpdateSingleSkillRedeploysInstalledAgentWorkspace(t *testing.T) {
+func TestUpdateSingleSkillReportsRedeployFailureAndContinues(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
@@ -282,18 +282,24 @@ func TestUpdateSingleSkillRedeploysInstalledAgentWorkspace(t *testing.T) {
 		return "", nil
 	}
 
-	agentValue, err := agentService.CreateAgent(ctx, protocol.CreateRequest{Name: "技能更新助手"})
+	failingAgent, err := agentService.CreateAgent(ctx, protocol.CreateRequest{Name: "失败助手"})
 	if err != nil {
 		t.Fatalf("创建 agent 失败: %v", err)
+	}
+	successAgent, err := agentService.CreateAgent(ctx, protocol.CreateRequest{Name: "成功助手"})
+	if err != nil {
+		t.Fatalf("创建第二个 agent 失败: %v", err)
 	}
 	if _, err = service.ImportGitPath(ctx, "https://example.com/skills.git", "main", "skills/git-skill"); err != nil {
 		t.Fatalf("Git 导入失败: %v", err)
 	}
-	if _, err = service.InstallSkill(ctx, agentValue.AgentID, "git-skill"); err != nil {
-		t.Fatalf("安装 Git skill 失败: %v", err)
+	for _, agentValue := range []protocol.Agent{*failingAgent, *successAgent} {
+		if _, err = service.InstallSkill(ctx, agentValue.AgentID, "git-skill"); err != nil {
+			t.Fatalf("安装 Git skill 到 %s 失败: %v", agentValue.AgentID, err)
+		}
 	}
-	installedSkillPath := filepath.Join(agentValue.WorkspacePath, ".agents", "skills", "git-skill", "SKILL.md")
-	payload, err := os.ReadFile(installedSkillPath)
+	successSkillPath := filepath.Join(successAgent.WorkspacePath, ".agents", "skills", "git-skill", "SKILL.md")
+	payload, err := os.ReadFile(successSkillPath)
 	if err != nil {
 		t.Fatalf("读取已安装 skill 失败: %v", err)
 	}
@@ -301,17 +307,25 @@ func TestUpdateSingleSkillRedeploysInstalledAgentWorkspace(t *testing.T) {
 		t.Fatalf("初始安装内容不正确: %s", payload)
 	}
 
+	makeSkillDeploymentRootReadOnly(t, failingAgent.WorkspacePath)
 	activeRepo = repoV2
 	activeCommit = "commit-v2"
-	if _, err = service.UpdateSingleSkill(ctx, "git-skill"); err != nil {
+	detail, err := service.UpdateSingleSkill(ctx, "git-skill")
+	if err != nil {
 		t.Fatalf("更新 Git skill 失败: %v", err)
 	}
-	payload, err = os.ReadFile(installedSkillPath)
+	if len(detail.DeployFailures) != 1 || detail.DeployFailures[0].AgentID != failingAgent.AgentID {
+		t.Fatalf("未返回失败 Agent 信息: %+v", detail.DeployFailures)
+	}
+	if len(detail.DeploySuccesses) != 1 || detail.DeploySuccesses[0].AgentID != successAgent.AgentID {
+		t.Fatalf("未返回成功 Agent 信息: %+v", detail.DeploySuccesses)
+	}
+	payload, err = os.ReadFile(successSkillPath)
 	if err != nil {
 		t.Fatalf("读取更新后 skill 失败: %v", err)
 	}
 	if !strings.Contains(string(payload), "Git Skill v2") {
-		t.Fatalf("已安装 skill 未随库更新: %s", payload)
+		t.Fatalf("成功 Agent 的 skill 未随库更新: %s", payload)
 	}
 }
 
@@ -379,6 +393,17 @@ tags: [test]
 	if err = os.WriteFile(filepath.Join(root, ".nexus-skill.json"), payload, 0o644); err != nil {
 		t.Fatalf("写入测试 skill manifest 失败: %v", err)
 	}
+}
+
+func makeSkillDeploymentRootReadOnly(t *testing.T, workspacePath string) {
+	t.Helper()
+	skillRoot := filepath.Join(workspacePath, ".agents", "skills")
+	if err := os.Chmod(skillRoot, 0o555); err != nil {
+		t.Fatalf("设置只读 skill 目录失败: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(skillRoot, 0o755)
+	})
 }
 
 func newSkillsTestConfig(t *testing.T) config.Config {

--- a/web/src/features/capability/skills/skill-deploy-failures.ts
+++ b/web/src/features/capability/skills/skill-deploy-failures.ts
@@ -1,0 +1,16 @@
+import type { RedeployAgentFailure } from "@/types/capability/skill";
+
+export function format_deploy_failure_message(
+  skill_name: string,
+  failures?: RedeployAgentFailure[],
+): string | null {
+  const items = failures?.filter((item) => item.agent_id || item.agent_name || item.error) ?? [];
+  if (items.length === 0) return null;
+
+  const agents = items
+    .slice(0, 3)
+    .map((item) => item.agent_name || item.agent_id || "unknown")
+    .join("、");
+  const suffix = items.length > 3 ? `${agents} 等 ${items.length} 个 Agent` : agents;
+  return `已更新 ${skill_name}，但 ${items.length} 个 Agent 部署失败：${suffix}`;
+}

--- a/web/src/features/capability/skills/skill-detail-view.tsx
+++ b/web/src/features/capability/skills/skill-detail-view.tsx
@@ -21,6 +21,7 @@ import { UiPanel } from "@/shared/ui/panel";
 import { UiStateBlock } from "@/shared/ui/state-block";
 import type { SkillDetail } from "@/types/capability/skill";
 
+import { format_deploy_failure_message } from "./skill-deploy-failures";
 import { SkillMarkdown } from "./skill-markdown";
 
 interface SkillDetailViewProps {
@@ -48,12 +49,14 @@ export function SkillDetailView({
   const [loading, set_loading] = useState(true);
   const [active_action, set_active_action] = useState<"delete" | "update" | null>(null);
   const [error, set_error] = useState<string | null>(null);
+  const [warning, set_warning] = useState<string | null>(null);
   const source_url = skill?.source_ref && /^https?:\/\//.test(skill.source_ref) ? skill.source_ref : null;
 
   const load_detail = useCallback(async () => {
     try {
       set_loading(true);
       set_error(null);
+      set_warning(null);
       set_skill(await get_skill_detail_api(skill_name));
     } catch (err) {
       set_error(err instanceof Error ? err.message : "加载 skill 详情失败");
@@ -72,9 +75,11 @@ export function SkillDetailView({
     try {
       set_active_action("update");
       set_error(null);
-      await update_single_skill_api(skill.name);
+      set_warning(null);
+      const detail = await update_single_skill_api(skill.name);
       await Promise.resolve(on_refreshed());
       await load_detail();
+      set_warning(format_deploy_failure_message(skill.name, detail.deploy_failures));
     } catch (err) {
       set_error(err instanceof Error ? err.message : "更新 skill 失败");
     } finally {
@@ -87,6 +92,7 @@ export function SkillDetailView({
     try {
       set_active_action("delete");
       set_error(null);
+      set_warning(null);
       await delete_skill_api(skill.name);
       await Promise.resolve(on_deleted());
     } catch (err) {
@@ -204,6 +210,9 @@ export function SkillDetailView({
 
             {error ? (
               <UiStateBlock description={error} size="sm" title="操作失败" tone="danger" />
+            ) : null}
+            {warning ? (
+              <UiStateBlock description={warning} size="sm" title="部分完成" />
             ) : null}
 
             <section>

--- a/web/src/features/capability/skills/skills-directory.tsx
+++ b/web/src/features/capability/skills/skills-directory.tsx
@@ -61,6 +61,15 @@ export function SkillsDirectory({ on_replay_tour }: SkillsDirectoryProps) {
       tone: operation_pending ? "warning" : "success",
     });
   }
+  if (ctrl.warning_message) {
+    feedback_items.push({
+      key: "warning",
+      message: ctrl.warning_message,
+      on_dismiss: () => ctrl.set_warning_message(null),
+      title: "部分完成",
+      tone: "warning",
+    });
+  }
   if (ctrl.error_message) {
     feedback_items.push({
       key: "error",

--- a/web/src/features/capability/skills/skills-view-model.ts
+++ b/web/src/features/capability/skills/skills-view-model.ts
@@ -42,6 +42,7 @@ export interface SkillMarketplaceController {
   busy_skill_name: string | null;
   busy_external_key: string | null;
   status_message: string | null;
+  warning_message: string | null;
   error_message: string | null;
   file_input_ref: RefObject<HTMLInputElement | null>;
   categories: Array<{ key: string; label: string }>;
@@ -58,6 +59,7 @@ export interface SkillMarketplaceController {
   set_source_manager_open: (value: boolean) => void;
   set_import_dialog_mode: (value: SkillImportDialogMode | null) => void;
   set_status_message: (value: string | null) => void;
+  set_warning_message: (value: string | null) => void;
   set_error_message: (value: string | null) => void;
   refresh_marketplace: () => Promise<void>;
   submit_external_search: () => void;

--- a/web/src/hooks/capability/use-skill-marketplace.ts
+++ b/web/src/hooks/capability/use-skill-marketplace.ts
@@ -24,6 +24,7 @@ import type {
   SkillImportDialogMode,
   SkillMarketplaceController,
 } from "@/features/capability/skills/skills-view-model";
+import { format_deploy_failure_message } from "@/features/capability/skills/skill-deploy-failures";
 
 const MIN_EXTERNAL_SEARCH_LENGTH = 2;
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -63,6 +64,7 @@ export function useSkillMarketplace(): SkillMarketplaceController {
   const [importing_skill, set_importing_skill] = useState(false);
   const [busy_skill_name, set_busy_skill_name] = useState<string | null>(null);
   const [status_message, set_status_message] = useState<string | null>(null);
+  const [warning_message, set_warning_message] = useState<string | null>(null);
   const [error_message, set_error_message] = useState<string | null>(null);
   const file_input_ref = useRef<HTMLInputElement | null>(null);
   const external_search_request_ref = useRef(0);
@@ -244,6 +246,7 @@ export function useSkillMarketplace(): SkillMarketplaceController {
   const clear_messages = () => {
     set_check_update_message(null);
     set_status_message(null);
+    set_warning_message(null);
     set_error_message(null);
   };
 
@@ -271,8 +274,13 @@ export function useSkillMarketplace(): SkillMarketplaceController {
     clear_messages();
     try {
       set_busy_skill_name(skill_name);
-      await update_single_skill_api(skill_name);
-      set_status_message(`已更新 ${skill_name}`);
+      const detail = await update_single_skill_api(skill_name);
+      const deploy_failure_message = format_deploy_failure_message(skill_name, detail.deploy_failures);
+      if (deploy_failure_message) {
+        set_warning_message(deploy_failure_message);
+      } else {
+        set_status_message(`已更新 ${skill_name}`);
+      }
       await refresh_marketplace();
     } catch (err) {
       set_error_message(err instanceof Error ? err.message : "更新失败");
@@ -458,6 +466,7 @@ export function useSkillMarketplace(): SkillMarketplaceController {
     busy_skill_name,
     busy_external_key,
     status_message,
+    warning_message,
     error_message,
     file_input_ref,
     // 派生数据
@@ -476,6 +485,7 @@ export function useSkillMarketplace(): SkillMarketplaceController {
     set_source_manager_open,
     set_import_dialog_mode,
     set_status_message,
+    set_warning_message,
     set_error_message,
     // 操作
     refresh_marketplace,

--- a/web/src/types/capability/skill.ts
+++ b/web/src/types/capability/skill.ts
@@ -34,6 +34,8 @@ export interface SkillInfo {
 export interface SkillDetail extends SkillInfo {
     readme_markdown: string;
     recommendation: string;
+    deploy_successes?: RedeployAgentSuccess[];
+    deploy_failures?: RedeployAgentFailure[];
 }
 
 export interface AgentSkillEntry extends SkillInfo {}
@@ -41,6 +43,21 @@ export interface AgentSkillEntry extends SkillInfo {}
 export interface SkillActionFailure {
     skill_name: string;
     error: string;
+}
+
+export interface RedeployAgentSuccess {
+    agent_id: string;
+    agent_name: string;
+}
+
+export interface RedeployAgentFailure extends RedeployAgentSuccess {
+    error: string;
+}
+
+export interface SkillRedeployResult {
+    skill_name: string;
+    success_agents: RedeployAgentSuccess[];
+    failures: RedeployAgentFailure[];
 }
 
 export interface BatchInstallSkillsResponse {
@@ -52,6 +69,7 @@ export interface UpdateInstalledSkillsResponse {
     updated_skills: string[];
     skipped_skills: string[];
     failures: SkillActionFailure[];
+    deploy_results?: SkillRedeployResult[];
 }
 
 export interface CheckSkillUpdatesResponse {


### PR DESCRIPTION
## Fix for #182

### Problem

`redeploySkillToInstalledAgents` 在遍历已安装技能的多个 Agent 时，遇到第一个错误就 `return err`，导致剩余 Agent 不会收到更新部署。多 Agent 场景下会导致技能版本不一致，且调用方无法得知哪些 Agent 成功、哪些失败。

### Changes

- **`redeploySkillToInstalledAgents`** 改为收集 per-Agent 错误而非 fail-fast，返回 `*RedeployResult`（成功列表 + 失败列表）
- 新增 `RedeployResult` 和 `RedeployAgentFailure` 类型
- **`UpdateImportedSkills`**：per-Agent 失败会记录到 `result.Failures`，若至少一个 Agent 成功则仍标记为已更新
- **`UpdateSingleSkill`**：部分失败信息通过 `Detail.DeployFailures` 返回（向后兼容的新字段）
- 所有 Agent 独立处理，互不影响

### Testing

- `go build ./...` ✅
- `go test ./internal/service/skills/...` ✅
- `go vet ./...` ✅

Closes #182