### PR TITLE
fix: #186 Login handler calls logout first, aborting login if logout fails

### DIFF
--- a/internal/handler/auth/handlers.go
+++ b/internal/handler/auth/handlers.go
@@ -62,11 +62,6 @@ func (h *Handlers) HandleAuthLogin(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	if err := h.auth.Logout(request.Context(), h.auth.ExtractSessionToken(request)); err != nil {
-		h.api.WriteFailure(writer, http.StatusInternalServerError, err.Error())
-		return
-	}
-
 	result, err := h.auth.Login(request.Context(), authsvc.LoginInput{
 		Username:  payload.Username,
 		Password:  payload.Password,
@@ -87,6 +82,11 @@ func (h *Handlers) HandleAuthLogin(writer http.ResponseWriter, request *http.Req
 			h.api.WriteFailure(writer, http.StatusInternalServerError, err.Error())
 		}
 		return
+	}
+
+	// Best-effort cleanup of the previous session; failures must not block login.
+	if logoutErr := h.auth.Logout(request.Context(), h.auth.ExtractSessionToken(request)); logoutErr != nil {
+		h.api.BaseLogger().Warn("failed to clear previous session during login", "error", logoutErr.Error())
 	}
 
 	http.SetCookie(writer, &http.Cookie{


### PR DESCRIPTION
## Fix for #186

### Problem
`HandleAuthLogin` called `Logout` **before** attempting `Login`. If the current session token was corrupted, or the database errored during session deletion, the entire login flow was aborted with HTTP 500 — even when the user provided correct credentials.

This particularly hurts users trying to recover from a broken session by re-logging in.

### Fix
Reorder the flow: **login first, logout old session after**.

1. Validate credentials and create the new session via `Login()`.
2. Only after successful login, attempt to clean up the previous session.
3. If old-session cleanup fails, log a warning but **do not** abort — the user is already authenticated.

### Changes
- `internal/handler/auth/handlers.go`: Moved `Logout` call to after successful `Login`, changed hard failure to `Warn` log.

### Testing
- [x] `go build ./internal/handler/auth/...` — passes
- [x] `go vet ./internal/handler/auth/...` — passes
- [x] `go test ./internal/handler/auth/...` — all tests pass

### Risk
Very low. The change is purely defensive — login succeeds in all cases it did before, and now also succeeds when the old session is corrupted.