### PR TITLE
fix: #190 Build scripts: curl in resolve-nxs-runtime-release.sh has no timeout, can hang CI builds indefinitely

### DIFF
--- a/scripts/resolve-nxs-runtime-release.sh
+++ b/scripts/resolve-nxs-runtime-release.sh
@@ -22,7 +22,7 @@ esac
 
 repo="${NEXUS_NXS_RUNTIME_RELEASE_REPO:-${NEXUS_DESKTOP_NXS_RELEASE_REPO:-nexus-research-lab/nexus-agent-sdk-bridge}}"
 manifest_url="${NEXUS_NXS_RUNTIME_MANIFEST_URL:-${NEXUS_DESKTOP_NXS_MANIFEST_URL:-https://github.com/${repo}/releases/download/${release}/nxs-manifest.json}}"
-manifest="$(curl -fsSL "${manifest_url}")"
+manifest="$(curl -fsSL --connect-timeout 10 --max-time 30 "${manifest_url}")"
 resolved="$(printf '%s\n' "${manifest}" | sed -n 's/.*"release_tag"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
 
 if [ -z "${resolved}" ]; then


### PR DESCRIPTION
## Fix for #190

### Problem
`scripts/resolve-nxs-runtime-release.sh` calls `curl -fsSL` without any timeout parameters. If GitHub CDN is unreachable, DNS hangs, or TCP connection is slow, the script — and by extension `make build`, `make start`, and `make deploy` — will hang indefinitely.

### Fix
Add `--connect-timeout 10 --max-time 30` to the `curl` invocation:
- `--connect-timeout 10`: TCP connection must complete within 10 seconds
- `--max-time 30`: entire request (including data transfer) capped at 30 seconds

This is a 1-line change with zero risk to normal operation (typical requests complete in 1-2s).

### Testing
- [x] Script syntax valid (`sh -n`)
- [x] Normal operation unaffected (timeout values well above typical response time)
- [x] Fails fast on network issues instead of hanging