### PR TITLE
fix: #199 main 分支编译失败：nexus-agent-sdk-bridge v0.1.18 缺少 RemoveMessages 方法

### DIFF
--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -164,12 +164,11 @@ func (c *sdkClientAdapter) SendTaskMessage(ctx context.Context, taskID string, m
 	return session.Control().SendTaskMessage(ctx, taskID, message, summary)
 }
 
-func (c *sdkClientAdapter) RemoveMessages(ctx context.Context, uuids []string) error {
-	session, err := c.currentSession()
-	if err != nil {
-		return err
-	}
-	return session.Control().RemoveMessages(ctx, uuids)
+func (c *sdkClientAdapter) RemoveMessages(_ context.Context, _ []string) error {
+	// TODO: session.Control().RemoveMessages is not available in nexus-agent-sdk-bridge v0.1.18.
+	// This is a temporary no-op until a newer SDK version is released.
+	// See: https://github.com/nexus-research-lab/nexus/issues/199
+	return nil
 }
 
 func (c *sdkClientAdapter) SetPermissionMode(ctx context.Context, mode sdkpermission.Mode) error {


### PR DESCRIPTION
修复 #199

**问题：**
commit 971409a2 引入了 `session.Control().RemoveMessages` 的调用，但 `go.mod` 锁定的 `nexus-agent-sdk-bridge v0.1.18` 没有该方法，且通过 `go list -m -versions` 确认 v0.1.18 是当前已发布的最新版本。这导致 `go build ./...` 和 `go test ./...` 全部失败。

**修复：**
将 `sdkClientAdapter.RemoveMessages` 暂时改为 no-op，等 SDK 发布包含该方法的版本后再恢复。

- 不影响现有接口定义
- 最小改动，仅编译修复
- 已在本地通过 `go build ./...` 验证

---
*PR 创建后不自动合并，等待代码审查。*