### PR TITLE
fix: #194 Quota enforcement blocks internal goal continuation/resume

### DIFF
--- a/internal/service/dm/quota_test.go
+++ b/internal/service/dm/quota_test.go
@@ -52,3 +52,36 @@ func TestServiceHandleChatBlocksRuntimeWhenQuotaExceeded(t *testing.T) {
 		t.Fatalf("quota exceeded 时不应创建或连接 runtime: options=%+v connect_calls=%d", got, client.connectCalls)
 	}
 }
+
+func TestServiceHandleChatBypassesQuotaForInternalRequests(t *testing.T) {
+	cfg := newDMTestConfig(t)
+	migrateDMSQLite(t, cfg.DatabaseURL)
+
+	agentService := newDMAgentService(t, cfg)
+	permission := permissionctx.NewContext()
+	client := newFakeDMClient()
+	factory := &fakeDMFactory{client: client}
+	service := NewService(cfg, agentService, runtimectx.NewManagerWithFactory(factory), permission)
+	errQuota := errors.New("quota exceeded")
+	service.SetQuotaChecker(fakeDMQuotaChecker{err: errQuota})
+
+	ctx := authsvc.WithPrincipal(context.Background(), &authsvc.Principal{
+		UserID: "owner-internal-quota",
+		Role:   authsvc.RoleOwner,
+	})
+	agentValue, err := agentService.CreateAgent(ctx, protocol.CreateRequest{Name: "Internal Quota Agent"})
+	if err != nil {
+		t.Fatalf("创建测试 agent 失败: %v", err)
+	}
+	sessionKey := protocol.BuildAgentSessionKey(agentValue.AgentID, protocol.SessionChannelWebSocketSegment, protocol.RoomTypeDM, "internal-quota", "")
+	err = service.HandleChat(ctx, Request{
+		SessionKey: sessionKey,
+		Content:    "internal goal continuation",
+		RoundID:    "round-internal-quota",
+		Internal:   true,
+	})
+	// Internal requests should bypass quota check — error should NOT be quota exceeded
+	if errors.Is(err, errQuota) {
+		t.Fatalf("internal request 不应被 quota 阻止，但返回了 quota exceeded")
+	}
+}

--- a/internal/service/dm/request.go
+++ b/internal/service/dm/request.go
@@ -162,8 +162,10 @@ func (e *dmChatExecution) routeRunningInput() (bool, error) {
 }
 
 func (e *dmChatExecution) prepareRunner() error {
-	if err := e.service.ensureQuotaAvailable(e.ctx); err != nil {
-		return err
+	if !e.request.Internal {
+		if err := e.service.ensureQuotaAvailable(e.ctx); err != nil {
+			return err
+		}
 	}
 	if err := e.interruptRunningRound(); err != nil {
 		return err

--- a/internal/service/room/chat.go
+++ b/internal/service/room/chat.go
@@ -201,7 +201,7 @@ func (s *RealtimeService) prepareRoomChat(ctx context.Context, request ChatReque
 			targetResolution,
 		)
 	}
-	if len(targetAgentIDs) > 0 {
+	if len(targetAgentIDs) > 0 && !request.Internal {
 		if err = s.ensureQuotaAvailable(ctx); err != nil {
 			return nil, err
 		}

--- a/internal/service/room/chat_runtime_test.go
+++ b/internal/service/room/chat_runtime_test.go
@@ -163,6 +163,75 @@ func TestRealtimeServiceCompletesRoomRoundFromTerminalAssistantWithoutResult(t *
 	}
 }
 
+func TestRealtimeServiceHandleChatBypassesQuotaForInternalRequests(t *testing.T) {
+	cfg := newRoomTestConfig(t)
+	migrateRoomSQLite(t, cfg.DatabaseURL)
+
+	agentService, db, err := serverapp.NewAgentService(cfg)
+	if err != nil {
+		t.Fatalf("创建 agent service 失败: %v", err)
+	}
+	roomService := serverapp.NewRoomServiceWithDB(cfg, db, agentService)
+	if err != nil {
+		t.Fatalf("创建 room service 失败: %v", err)
+	}
+
+	ctx := authsvc.WithPrincipal(context.Background(), &authsvc.Principal{
+		UserID:   "owner-room-internal-quota",
+		Username: "room-owner",
+		Role:     authsvc.RoleOwner,
+	})
+	memberAgent := createTestAgent(t, agentService, ctx, "内部额度助手")
+	dmContext, err := roomService.EnsureDirectRoom(ctx, memberAgent.AgentID)
+	if err != nil {
+		t.Fatalf("创建直聊 room 失败: %v", err)
+	}
+
+	client := newFakeRoomClient()
+	client.onQuery = func(_ context.Context, _ string) error {
+		go sendFakeAssistantResult(client, "assistant-internal-quota", "内部续跑完成")
+		return nil
+	}
+
+	factory := &fakeRoomFactory{clients: []*fakeRoomClient{client}}
+	permission := permissionctx.NewContext()
+	runtimeManager := runtimectx.NewManager()
+	service := roomsvc.NewRealtimeServiceWithFactory(
+		cfg,
+		roomService,
+		agentService,
+		runtimeManager,
+		permission,
+		factory,
+	)
+	errQuota := errors.New("quota exceeded")
+	service.SetQuotaChecker(fakeRoomQuotaChecker{err: errQuota})
+
+	sharedSessionKey := protocol.BuildRoomSharedSessionKey(dmContext.Conversation.ID)
+	sender := newRealtimeTestSender("room-sender-internal-quota")
+	permission.BindSession(sharedSessionKey, sender)
+
+	err = service.HandleChat(ctx, roomsvc.ChatRequest{
+		SessionKey:     sharedSessionKey,
+		RoomID:         dmContext.Room.ID,
+		ConversationID: dmContext.Conversation.ID,
+		Content:        "internal goal continuation",
+		RoundID:        "room-round-internal-quota",
+		Internal:       true,
+	})
+	if errors.Is(err, errQuota) {
+		t.Fatalf("internal request 不应被 quota 阻止，但返回了 quota exceeded")
+	}
+	if err != nil {
+		t.Fatalf("HandleChat 内部请求意外失败: %v", err)
+	}
+
+	// Wait for the round to finish so async goroutines complete before TempDir cleanup.
+	collectRoomEventsUntil(t, sender.events, func(_ []protocol.EventMessage, event protocol.EventMessage) bool {
+		return event.EventType == protocol.EventTypeRoundStatus && event.Data["status"] == "finished"
+	})
+}
+
 func TestRealtimeServiceKeepsSubagentRoomSlotInRuntimeManager(t *testing.T) {
 	cfg := newRoomTestConfig(t)
 	migrateRoomSQLite(t, cfg.DatabaseURL)


### PR DESCRIPTION
## Fix for #194

### Problem
When users reach their monthly token quota limit, system-internal operations (`Internal: true`) such as goal continuation and goal auto-resume are blocked by `ensureQuotaAvailable()`. This causes goals to permanently stall with no clear error path to recovery.

### Root Cause
Both `dm/request.go` and `room/chat.go` call `ensureQuotaAvailable()` unconditionally, without checking the `Internal` flag. Goal continuation dispatchers and resume handlers set `Internal: true`, but this flag was not used to bypass quota enforcement.

### Fix
Wrap the `ensureQuotaAvailable()` call in `!request.Internal` condition in both paths:

- `internal/service/dm/request.go`: Skip quota check when `request.Internal == true`
- `internal/service/room/chat.go`: Add `!request.Internal` to the existing quota check condition

### Tests
Added unit tests for both DM and Room paths verifying that `Internal: true` + quota exceeded does not block the request:
- `TestServiceHandleChatBypassesQuotaForInternalRequests` (DM)
- `TestRealtimeServiceHandleChatBypassesQuotaForInternalRequests` (Room)

All existing tests continue to pass.

### Risk
Minimal — one additional condition check per code path. No changes to `ensureQuotaAvailable()` itself. Existing quota enforcement for user-initiated requests remains unchanged.

Closes #194