### PR TITLE
Fix Goal state when subscription quota blocks continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kept subscription quota enforcement on internal Goal continuations and now project exhausted account quota as an actionable `usage_limited` Goal state instead of a generic continuation failure.
 - Fixed the Windows desktop release-notes build by explicitly selecting WPF alignment, font, color, and brush types.
 - Bound WebSearch API keys to their selected provider so a key from one provider is never displayed or reused under another provider.
 - Fixed desktop updates retaining old downloaded app and installer packages in `~/.nexus/cache/updates` after a newer version started successfully; deferred downloads remain available until then.

--- a/internal/service/dm/doc.go
+++ b/internal/service/dm/doc.go
@@ -8,7 +8,7 @@
 //   - goal_continuation.go / goal_context.go / goal_runtime.go：Goal 续跑启动 claim、上下文、消费后 revision adoption 与 fenced 结算。
 //   - history.go / rewrite.go / title.go：历史、SDK session/fingerprint 同步、重写、标题。
 //   - attachments.go / broadcast.go / external_reply.go：附件、广播、外部回复。
-//   - quota.go / subagent_task.go / runtime_client.go：额度、子任务、运行时客户端。
+//   - quota.go / subagent_task.go / runtime_client.go：账号额度门禁与 Goal 限制投影、子任务、运行时客户端。
 //
 // [PROTOCOL]: 变更时更新此头部，然后检查父级入口 AGENTS.md（L1）
 package dm

--- a/internal/service/dm/quota_test.go
+++ b/internal/service/dm/quota_test.go
@@ -9,10 +9,51 @@ import (
 	runtimectx "github.com/nexus-research-lab/nexus/internal/runtime"
 	permissionctx "github.com/nexus-research-lab/nexus/internal/runtime/permission"
 	authsvc "github.com/nexus-research-lab/nexus/internal/service/auth"
+	subscriptionsvc "github.com/nexus-research-lab/nexus/internal/service/subscription"
 )
 
 type fakeDMQuotaChecker struct {
 	err error
+}
+
+func TestServiceHandleChatMarksInternalGoalUsageLimitedWhenQuotaExceeded(t *testing.T) {
+	cfg := newDMTestConfig(t)
+	migrateDMSQLite(t, cfg.DatabaseURL)
+
+	agentService := newDMAgentService(t, cfg)
+	client := newFakeDMClient()
+	factory := &fakeDMFactory{client: client}
+	service := NewService(cfg, agentService, runtimectx.NewManagerWithFactory(factory), permissionctx.NewContext())
+	goalProvider := &fakeGoalContextProvider{}
+	service.SetGoalContextProvider(goalProvider)
+	quotaErr := subscriptionsvc.QuotaExceededError{UsedTokens: 10, LimitTokens: 10}
+	service.SetQuotaChecker(fakeDMQuotaChecker{err: quotaErr})
+
+	ctx := authsvc.WithPrincipal(context.Background(), &authsvc.Principal{
+		UserID: "owner-internal-goal-quota",
+		Role:   authsvc.RoleOwner,
+	})
+	agentValue, err := agentService.CreateAgent(ctx, protocol.CreateRequest{Name: "Internal Goal Quota Agent"})
+	if err != nil {
+		t.Fatalf("创建测试 agent 失败: %v", err)
+	}
+	sessionKey := protocol.BuildAgentSessionKey(agentValue.AgentID, protocol.SessionChannelWebSocketSegment, protocol.RoomTypeDM, "internal-goal-quota", "")
+	err = service.HandleChat(ctx, Request{
+		SessionKey: sessionKey,
+		Content:    "internal goal continuation",
+		GoalID:     "goal-internal-quota",
+		RoundID:    "round-internal-goal-quota",
+		Internal:   true,
+	})
+	if !errors.Is(err, subscriptionsvc.ErrQuotaExceeded) {
+		t.Fatalf("账号额度耗尽应阻止内部 Goal runtime，实际: %v", err)
+	}
+	if got := goalProvider.recordedUsageLimitReasons(); len(got) != 1 || got[0] != quotaErr.ClientMessage() {
+		t.Fatalf("Goal usage limit reasons = %#v, want actionable subscription quota message", got)
+	}
+	if got := factory.LastOptions(); got.Model != "" || client.connectCalls != 0 {
+		t.Fatalf("账号额度耗尽时不应创建或连接内部 Goal runtime: options=%+v connect_calls=%d", got, client.connectCalls)
+	}
 }
 
 func (f fakeDMQuotaChecker) EnsureQuotaAvailable(context.Context, string) error {

--- a/internal/service/dm/request.go
+++ b/internal/service/dm/request.go
@@ -163,6 +163,9 @@ func (e *dmChatExecution) routeRunningInput() (bool, error) {
 
 func (e *dmChatExecution) prepareRunner() error {
 	if err := e.service.ensureQuotaAvailable(e.ctx); err != nil {
+		if e.request.Internal && strings.TrimSpace(e.request.GoalID) != "" {
+			e.service.recordGoalQuotaLimit(e.ctx, e.sessionKey, e.request.RoundID, err)
+		}
 		return err
 	}
 	if err := e.interruptRunningRound(); err != nil {

--- a/internal/service/room/chat.go
+++ b/internal/service/room/chat.go
@@ -203,6 +203,9 @@ func (s *RealtimeService) prepareRoomChat(ctx context.Context, request ChatReque
 	}
 	if len(targetAgentIDs) > 0 {
 		if err = s.ensureQuotaAvailable(ctx); err != nil {
+			if request.Internal && strings.TrimSpace(request.GoalID) != "" {
+				s.recordGoalQuotaLimit(ctx, sessionKey, request.RoundID, err)
+			}
 			return nil, err
 		}
 	}

--- a/internal/service/room/chat_runtime_test.go
+++ b/internal/service/room/chat_runtime_test.go
@@ -11,8 +11,11 @@ import (
 	runtimectx "github.com/nexus-research-lab/nexus/internal/runtime"
 	permissionctx "github.com/nexus-research-lab/nexus/internal/runtime/permission"
 	authsvc "github.com/nexus-research-lab/nexus/internal/service/auth"
+	goalsvc "github.com/nexus-research-lab/nexus/internal/service/goal"
 	roomsvc "github.com/nexus-research-lab/nexus/internal/service/room"
+	subscriptionsvc "github.com/nexus-research-lab/nexus/internal/service/subscription"
 	usagesvc "github.com/nexus-research-lab/nexus/internal/service/usage"
+	goalstore "github.com/nexus-research-lab/nexus/internal/storage/goal"
 	workspacestore "github.com/nexus-research-lab/nexus/internal/storage/workspace"
 
 	sdkprotocol "github.com/nexus-research-lab/nexus-agent-sdk-bridge/protocol"
@@ -21,6 +24,74 @@ import (
 
 type fakeRoomQuotaChecker struct {
 	err error
+}
+
+func TestRealtimeServiceHandleChatMarksInternalGoalUsageLimitedWhenQuotaExceeded(t *testing.T) {
+	cfg := newRoomTestConfig(t)
+	cfg.GoalEnabled = true
+	migrateRoomSQLite(t, cfg.DatabaseURL)
+
+	agentService, db, err := serverapp.NewAgentService(cfg)
+	if err != nil {
+		t.Fatalf("创建 agent service 失败: %v", err)
+	}
+	roomService := serverapp.NewRoomServiceWithDB(cfg, db, agentService)
+	ctx := authsvc.WithPrincipal(context.Background(), &authsvc.Principal{
+		UserID:   "owner-room-internal-goal-quota",
+		Username: "room-owner",
+		Role:     authsvc.RoleOwner,
+	})
+	memberAgent := createTestAgent(t, agentService, ctx, "内部 Goal 额度助手")
+	dmContext, err := roomService.EnsureDirectRoom(ctx, memberAgent.AgentID)
+	if err != nil {
+		t.Fatalf("创建直聊 room 失败: %v", err)
+	}
+
+	factory := &fakeRoomFactory{clients: []*fakeRoomClient{newFakeRoomClient()}}
+	service := roomsvc.NewRealtimeServiceWithFactory(
+		cfg,
+		roomService,
+		agentService,
+		runtimectx.NewManager(),
+		permissionctx.NewContext(),
+		factory,
+	)
+	goalService := goalsvc.NewService(cfg, goalstore.NewRepository(cfg, db))
+	service.SetGoalContextProvider(goalService)
+	quotaErr := subscriptionsvc.QuotaExceededError{UsedTokens: 10, LimitTokens: 10}
+	service.SetQuotaChecker(fakeRoomQuotaChecker{err: quotaErr})
+
+	sharedSessionKey := protocol.BuildRoomSharedSessionKey(dmContext.Conversation.ID)
+	goal, err := goalService.Create(ctx, protocol.CreateGoalRequest{
+		SessionKey:  sharedSessionKey,
+		Objective:   "保持账号额度边界",
+		OwnerUserID: "owner-room-internal-goal-quota",
+	})
+	if err != nil {
+		t.Fatalf("创建 Room Goal 失败: %v", err)
+	}
+	err = service.HandleChat(ctx, roomsvc.ChatRequest{
+		SessionKey:     sharedSessionKey,
+		RoomID:         dmContext.Room.ID,
+		ConversationID: dmContext.Conversation.ID,
+		Content:        "internal goal continuation",
+		GoalID:         goal.ID,
+		RoundID:        "room-round-internal-goal-quota",
+		Internal:       true,
+	})
+	if !errors.Is(err, subscriptionsvc.ErrQuotaExceeded) {
+		t.Fatalf("账号额度耗尽应阻止内部 Room Goal runtime，实际: %v", err)
+	}
+	limited, err := goalService.Current(ctx, sharedSessionKey)
+	if err != nil {
+		t.Fatalf("读取受限 Room Goal 失败: %v", err)
+	}
+	if limited.Status != protocol.GoalStatusUsageLimited || limited.LastError != quotaErr.ClientMessage() {
+		t.Fatalf("受限 Room Goal = %#v, want usage_limited with actionable subscription quota message", limited)
+	}
+	if got := factory.LastOptions(); got.Model != "" {
+		t.Fatalf("账号额度耗尽时不应创建内部 Room Goal runtime: %+v", got)
+	}
 }
 
 func (f fakeRoomQuotaChecker) EnsureQuotaAvailable(context.Context, string) error {

--- a/internal/service/room/doc.go
+++ b/internal/service/room/doc.go
@@ -12,6 +12,7 @@
 //   - input_queue.go / input_queue_* / guidance_input.go：跨成员 durable 幂等受理、按 Agent 串行队列、round 终态确定性接力、逐批 applied ACK、transport/错过 hook 回退、运行时补充上下文与已消费引导归组。
 //   - public_context.go：按 runtime resume 状态装配预算化 anchor/delta，并提交真实消费 cursor。
 //   - attachments.go：Room 公共附件上传、归一化与运行时路径解析。
+//   - quota.go：账号额度门禁，以及内部 Goal 被拦截后的 usage_limited 投影。
 //   - goal_*：Room 实时运行里的 Goal lead/成员目录对齐、逐 slot objective steering、消费后 revision adoption/fencing、续跑启动 claim 与 active/queued/wake completion readiness。
 //   - privateview/：Agent 私域 thread/event 投影。
 //   - runtimepolicy/：Room MCP 工具白名单和权限策略。

--- a/internal/service/room/quota.go
+++ b/internal/service/room/quota.go
@@ -1,7 +1,7 @@
-// INPUT: 账号订阅额度、内部 Goal continuation 与当前 Goal 状态。
+// INPUT: 账号订阅额度、内部 Room Goal continuation 与当前 Goal 状态。
 // OUTPUT: runtime 启动门禁，以及额度耗尽时的 Goal usage_limited 投影。
-// POS: DM 账号额度和 Goal 状态之间的适配边界。
-package dm
+// POS: Room 账号额度和 Goal 状态之间的适配边界。
+package room
 
 import (
 	"context"
@@ -17,18 +17,18 @@ type quotaChecker interface {
 }
 
 // SetQuotaChecker 注入订阅额度检查器。
-func (s *Service) SetQuotaChecker(checker quotaChecker) {
+func (s *RealtimeService) SetQuotaChecker(checker quotaChecker) {
 	s.quota = checker
 }
 
-func (s *Service) ensureQuotaAvailable(ctx context.Context) error {
+func (s *RealtimeService) ensureQuotaAvailable(ctx context.Context) error {
 	if s.quota == nil {
 		return nil
 	}
 	return s.quota.EnsureQuotaAvailable(ctx, authctx.OwnerUserID(ctx))
 }
 
-func (s *Service) recordGoalQuotaLimit(ctx context.Context, sessionKey string, roundID string, quotaErr error) {
+func (s *RealtimeService) recordGoalQuotaLimit(ctx context.Context, sessionKey string, roundID string, quotaErr error) {
 	if s.goals == nil || quotaErr == nil {
 		return
 	}
@@ -40,7 +40,7 @@ func (s *Service) recordGoalQuotaLimit(ctx context.Context, sessionKey string, r
 		!errors.Is(err, goalsvc.ErrGoalDisabled) &&
 		!errors.Is(err, goalsvc.ErrGoalNotFound) &&
 		!errors.Is(err, goalsvc.ErrGoalInvalidState) {
-		s.loggerFor(ctx).Warn("标记 Goal 账号额度限制失败",
+		s.loggerFor(ctx).Warn("标记 Room Goal 账号额度限制失败",
 			"session_key", sessionKey,
 			"round_id", roundID,
 			"err", err,

--- a/internal/service/room/service.go
+++ b/internal/service/room/service.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/nexus-research-lab/nexus/internal/config"
-	"github.com/nexus-research-lab/nexus/internal/infra/authctx"
 	"github.com/nexus-research-lab/nexus/internal/protocol"
 	agentsvc "github.com/nexus-research-lab/nexus/internal/service/agent"
 	"github.com/nexus-research-lab/nexus/internal/storage/roomrepo"
@@ -52,10 +51,6 @@ type runtimeSessionCloser interface {
 	CloseSession(context.Context, string) error
 }
 
-type quotaChecker interface {
-	EnsureQuotaAvailable(context.Context, string) error
-}
-
 // Service 提供 Room 编排能力。
 type Service struct {
 	config     config.Config
@@ -87,16 +82,4 @@ func (s *Service) SetGoalCleaner(cleaner goalCleaner) {
 // SetRuntimeManager 注入运行时管理器，用于关闭 Room conversation 对应的后台 client。
 func (s *Service) SetRuntimeManager(runtimeManager runtimeSessionCloser) {
 	s.runtime = runtimeManager
-}
-
-// SetQuotaChecker 注入订阅额度检查器。
-func (s *RealtimeService) SetQuotaChecker(checker quotaChecker) {
-	s.quota = checker
-}
-
-func (s *RealtimeService) ensureQuotaAvailable(ctx context.Context) error {
-	if s.quota == nil {
-		return nil
-	}
-	return s.quota.EnsureQuotaAvailable(ctx, authctx.OwnerUserID(ctx))
 }


### PR DESCRIPTION
## Summary
- keep account-level subscription quota enforcement for internal DM and Room Goal continuations
- project a blocked continuation to the existing `usage_limited` Goal state with the actionable subscription message
- add DM and Room regression coverage and keep the Room quota adapter in a focused module

`Internal` marks hidden/synthetic orchestration; it must not become an unmetered path around the monthly account quota. This replaces the bypass proposed in #195 and #202 while addressing the valid Goal-state visibility concern.

## Validation
- `NEXUS_CONFIG_DIR=<temp> GOWORK=off go test ./...`
- `corepack pnpm@9.15.2 --dir web run lint`
- `corepack pnpm@9.15.2 --dir web run test:timeline`
- `corepack pnpm@9.15.2 --dir web run typecheck`

Closes #194