### PR TITLE
fix: #210 前端 typecheck 失败：skill-detail-model.ts 缺少 SkillInfo 类型导入

### DIFF
--- a/web/src/features/capability/skills/detail/skill-detail-model.ts
+++ b/web/src/features/capability/skills/detail/skill-detail-model.ts
@@ -1,5 +1,6 @@
 import type {
   SkillDetail,
+  SkillInfo,
   SkillSourceType,
 } from "@/types/capability/skill";
 


### PR DESCRIPTION
## Fix #210

### 问题
`pnpm run typecheck` 失败，`skill-detail-model.ts` 第 61 行使用了 `SkillInfo` 类型但未从 `@/types/capability/skill` 导入，导致 TS2304 和 TS7053 错误。

### 修复
在 import 语句中添加 `SkillInfo` 类型导入（一行修复）。

### 验证
- `pnpm run typecheck` ✅ 通过（零错误）

### 引入提交
`a75bd271` — ":sparkles: Share platform Skills across runtimes"

关联 issue: closes #210