### PR TITLE
fix: #222 Build regression: workspaceisolation references undefined bridge SDK ProcessSignalHandler/ProcessSignal types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/larksuite/oapi-sdk-go/v3 v3.9.2
-	github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.28
+	github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.29-0.20260814135442-de0160a754d6
 	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pressly/goose/v3 v3.27.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6B
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.28 h1:PNYzmFRQpQmN6v/RBBBPCrfLRuT4kIh+NUjP9oyRoIs=
-github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.28/go.mod h1:vrO/rqDQJM2orurZpB49MfPX4LjSNlb6DQZAmELJw1Y=
+github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.29-0.20260814135442-de0160a754d6 h1:hNvsI81A1zkZxWzdzUTvRqs6xOvmXNFePCwQFc5V/Rc=
+github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.29-0.20260814135442-de0160a754d6/go.mod h1:vrO/rqDQJM2orurZpB49MfPX4LjSNlb6DQZAmELJw1Y=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1 h1:Lb/Uzkiw2Ugt2Xf03J5wmv81PdkYOiWbI8CNBi1boC8=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1/go.mod h1:ln3IqPYYocZbYvl9TAOrG/cxGR9xcn4pnZRLdCTEGEU=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=


### PR DESCRIPTION
## 修复内容

升级 `github.com/nexus-research-lab/nexus-agent-sdk-bridge`：`v0.1.28` → `v0.1.29-0.20260814135442-de0160a754d6`（main 分支最新提交，与引入回归的 commit `3f8e73c13` 同日发布）。

该版本包含 `ProcessSignalHandler` / `ProcessSignal` / `WithProcessSignalHandler` API（已核实 `client/options_builders.go`、`client/transport_config.go`），go.mod 此前未同步更新导致构建失败。

## 验证

- `go build ./...` ✅
- `go test ./internal/runtime/workspaceisolation/...` ✅
- `go test ./...` ✅（全量通过，无失败包）
- `go test -race ./internal/service/room/realtime/...` ✅

未运行 macOS app smoke workflow（需 CI 环境），建议合并前观察 CI 结果。

Fixes #222