### PR TITLE
fix: #225 【代码建议】关于nxs.exe的路径指定

### DIFF
--- a/desktop/macos/Sources/NexusDesktop/Sidecar/SidecarSupervisor.swift
+++ b/desktop/macos/Sources/NexusDesktop/Sidecar/SidecarSupervisor.swift
@@ -211,7 +211,8 @@ final class SidecarSupervisor {
       ])
       return
     }
-    if let override = environment["NEXUS_NXS_COMMAND_PATH"], !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+    let override = environment["NEXUS_NXS_COMMAND_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let override, !override.isEmpty, FileManager.default.isExecutableFile(atPath: override) {
       startupTimeline?.mark("sidecar.nxs_runtime", metadata: [
         "source": "override",
         "path": override,
@@ -221,15 +222,23 @@ final class SidecarSupervisor {
     let nxsURL = locator.appRootURL.appendingPathComponent("bin/nxs")
     if FileManager.default.isExecutableFile(atPath: nxsURL.path) {
       environment["NEXUS_NXS_COMMAND_PATH"] = nxsURL.path
-      startupTimeline?.mark("sidecar.nxs_runtime", metadata: [
+      var metadata = [
         "source": "bundled",
         "path": nxsURL.path,
-      ])
+      ]
+      if let override, !override.isEmpty {
+        metadata["ignored_override"] = override
+      }
+      startupTimeline?.mark("sidecar.nxs_runtime", metadata: metadata)
       return
     }
-    startupTimeline?.mark("sidecar.nxs_runtime", metadata: [
+    var metadata = [
       "source": "missing",
-    ])
+    ]
+    if let override, !override.isEmpty {
+      metadata["invalid_override"] = override
+    }
+    startupTimeline?.mark("sidecar.nxs_runtime", metadata: metadata)
   }
 
   private func connectorCredentialsKeyMode(environment: [String: String]) -> DesktopKeychainMode {

--- a/desktop/windows/Nexus.Desktop/Sidecar/SidecarSupervisor.cs
+++ b/desktop/windows/Nexus.Desktop/Sidecar/SidecarSupervisor.cs
@@ -269,33 +269,48 @@ internal sealed class SidecarSupervisor : IDisposable
             return;
         }
 
-        if (startInfo.Environment.TryGetValue("NEXUS_NXS_COMMAND_PATH", out string? overridePath) &&
-            !string.IsNullOrWhiteSpace(overridePath))
+        string? overridePath = null;
+        if (startInfo.Environment.TryGetValue("NEXUS_NXS_COMMAND_PATH", out string? configuredOverridePath) &&
+            !string.IsNullOrWhiteSpace(configuredOverridePath))
         {
-            startupTimeline.Mark("sidecar.nxs_runtime", new Dictionary<string, string>
+            overridePath = configuredOverridePath.Trim();
+            if (File.Exists(overridePath))
             {
-                ["source"] = "override",
-                ["path"] = overridePath,
-            });
-            return;
+                startupTimeline.Mark("sidecar.nxs_runtime", new Dictionary<string, string>
+                {
+                    ["source"] = "override",
+                    ["path"] = overridePath,
+                });
+                return;
+            }
         }
 
         string nxsPath = Path.Combine(locator.AppRoot, "bin", "nxs.exe");
         if (File.Exists(nxsPath))
         {
             startInfo.Environment["NEXUS_NXS_COMMAND_PATH"] = nxsPath;
-            startupTimeline.Mark("sidecar.nxs_runtime", new Dictionary<string, string>
+            Dictionary<string, string> metadata = new()
             {
                 ["source"] = "bundled",
                 ["path"] = nxsPath,
-            });
+            };
+            if (!string.IsNullOrWhiteSpace(overridePath))
+            {
+                metadata["ignored_override"] = overridePath;
+            }
+            startupTimeline.Mark("sidecar.nxs_runtime", metadata);
             return;
         }
 
-        startupTimeline.Mark("sidecar.nxs_runtime", new Dictionary<string, string>
+        Dictionary<string, string> missingMetadata = new()
         {
             ["source"] = "missing",
-        });
+        };
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            missingMetadata["invalid_override"] = overridePath;
+        }
+        startupTimeline.Mark("sidecar.nxs_runtime", missingMetadata);
     }
 
     private static void PrepareDirectories()


### PR DESCRIPTION
## What Problem This Solves

Packaged desktop builds could keep using a stale `NEXUS_NXS_COMMAND_PATH` override after the install folder was moved. The sidecar then pointed Agent runtime startup at the old absolute `nxs` path instead of the `nxs` binary bundled with the current app location.

## Why This Change Was Made

The packaged sidecar now treats an inherited `NEXUS_NXS_COMMAND_PATH` as valid only when it still points to an existing executable. If the override is stale, the sidecar falls back to the bundled runtime resolved from the current app root, so moving the install folder no longer breaks startup. Valid explicit overrides still work for users who intentionally provide a replacement runtime.

## User Impact

Users can move the packaged Nexus installation folder without the next startup failing because `NEXUS_NXS_COMMAND_PATH` still points to the previous location.

## Evidence

- `git diff --check` ✅
- `swift build --package-path desktop/macos` ✅
- `swift test --package-path desktop/macos` ⚠️ blocked locally because this Swift toolchain cannot load `XCTest` (`no such module 'XCTest'`); the package target itself builds successfully.
- Windows desktop build not run locally because the `dotnet` CLI is unavailable on this machine.

Fixes #225
