### PR TITLE
fix: #232 go vet: roomRoundRegistry returned by value copies sync.RWMutex

### DIFF
--- a/internal/service/room/realtime/chat.go
+++ b/internal/service/room/realtime/chat.go
@@ -885,7 +885,7 @@ func (s *Service) latestActiveRootRoundAgentIDs(sessionKey string, conversationI
 	slotsByRoot := make(map[string][]activeRoomTargetSlot)
 	latestTimestampByRoot := make(map[string]int64)
 	latestSequenceByRoot := make(map[string]uint64)
-	for _, roundValue := range s.rounds.snapshotConversation(conversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(conversationID) {
 		if roundValue == nil ||
 			roundValue.SessionKey != sessionKey ||
 			roundValue.ConversationID != conversationID {
@@ -1372,7 +1372,7 @@ func (s *Service) findActiveDeliverySlotsByAgent(
 		return result
 	}
 
-	for _, roundValue := range s.rounds.snapshotConversation(conversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(conversationID) {
 		if roundValue == nil ||
 			roundValue.SessionKey != sessionKey ||
 			roundValue.ConversationID != conversationID {
@@ -1415,7 +1415,7 @@ func (s *Service) findActiveDeliverySlots(
 	// active root 才能原子注入，避免同一 public message 被不同 root 反复改写。
 	slotsByRoot := make(map[string]map[string]*activeRoomSlot)
 	latestTimestampByRoot := make(map[string]int64)
-	for _, roundValue := range s.rounds.snapshotConversation(conversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(conversationID) {
 		if roundValue == nil ||
 			roundValue.SessionKey != sessionKey ||
 			roundValue.ConversationID != conversationID {

--- a/internal/service/room/realtime/conversation_rounds.go
+++ b/internal/service/room/realtime/conversation_rounds.go
@@ -38,20 +38,20 @@ type roomRoundRegistry struct {
 	conversations map[string]*roomConversationState
 }
 
-func newRoomRoundRegistry() roomRoundRegistry {
-	return roomRoundRegistry{
+func newRoomRoundRegistry() *roomRoundRegistry {
+	return &roomRoundRegistry{
 		conversations: make(map[string]*roomConversationState),
 	}
 }
 
-func newRoomRoundRegistryFromRounds(rounds map[string]*activeRoomRound) roomRoundRegistry {
+func newRoomRoundRegistryFromRounds(rounds map[string]*activeRoomRound) *roomRoundRegistry {
 	registry := &roomRoundRegistry{
 		conversations: make(map[string]*roomConversationState),
 	}
 	for _, roundValue := range rounds {
 		registry.register(roundValue)
 	}
-	return roomRoundRegistry{conversations: registry.conversations}
+	return registry
 }
 
 func newRoomConversationState() *roomConversationState {
@@ -508,7 +508,7 @@ type ActiveRoundSnapshot struct {
 // CountRunningTasks 返回指定 Agent 当前在 Room 中的活跃任务数。
 func (s *Service) CountRunningTasks(agentID string) int {
 	count := 0
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		for _, slot := range roundValue.Slots {
 			if slot != nil && slot.AgentID == agentID && !slot.isTerminal() {
 				count++
@@ -530,7 +530,7 @@ func (s *Service) SetPermissionModeForAgent(ctx context.Context, agentID string,
 		client runtimectx.Client
 	}
 	targets := make([]permissionModeTarget, 0)
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil {
 			continue
 		}
@@ -586,7 +586,7 @@ func (s *Service) GetActiveRoundSnapshot(conversationID string) *ActiveRoundSnap
 	pending := make([]protocol.ChatAckPendingSlot, 0)
 	snapshot := &ActiveRoundSnapshot{}
 	rootRoundIDs := make(map[string]struct{})
-	for _, roundValue := range s.rounds.snapshotConversation(conversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(conversationID) {
 		if roundValue == nil || roundValue.ConversationID != conversationID {
 			continue
 		}
@@ -642,7 +642,7 @@ func (s *Service) registerRound(roundValue *activeRoomRound) {
 	if roundValue == nil {
 		return
 	}
-	s.rounds.register(roundValue)
+	s.roundsRegistry().register(roundValue)
 }
 
 func (s *Service) finishRound(roundValue *activeRoomRound) {
@@ -650,7 +650,7 @@ func (s *Service) finishRound(roundValue *activeRoomRound) {
 		return
 	}
 	s.runtime.MarkRoundTerminal(roundValue.SessionKey, roundValue.RoundID)
-	s.rounds.unregister(roundValue)
+	s.roundsRegistry().unregister(roundValue)
 	roundValue.doneOnce.Do(func() {
 		close(roundValue.Done)
 	})
@@ -800,6 +800,13 @@ func roomDispatchStateKey(sessionKey string, conversationID string) string {
 	return "__room_unknown_conversation__"
 }
 
+func (s *Service) roundsRegistry() *roomRoundRegistry {
+	if s.rounds == nil {
+		s.rounds = newRoomRoundRegistry()
+	}
+	return s.rounds
+}
+
 func (s *Service) lockRoomDispatch(sessionKey string, conversationID string) *roomDispatchLease {
-	return s.rounds.acquireDispatch(roomDispatchStateKey(sessionKey, conversationID))
+	return s.roundsRegistry().acquireDispatch(roomDispatchStateKey(sessionKey, conversationID))
 }

--- a/internal/service/room/realtime/directed_message.go
+++ b/internal/service/room/realtime/directed_message.go
@@ -129,7 +129,7 @@ func (s *Service) roomDirectedReplyUsesAutomaticRoute(
 	if sourceAgentRoundID == "" {
 		return false
 	}
-	for _, roundValue := range s.rounds.snapshotConversation(message.ConversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(message.ConversationID) {
 		if roundValue == nil {
 			continue
 		}
@@ -170,7 +170,7 @@ func (s *Service) markActiveGoalCollaborationPending(
 	// belongs to its source round. Scan every live conversation and fence by the
 	// host-trusted root plus exact Goal revision so cross-conversation directed
 	// messages cannot let the source Goal continue early.
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil ||
 			(ownerUserID != "" && strings.TrimSpace(roundValue.OwnerUserID) != ownerUserID) ||
 			(rootRoundID != "" && roomRootRoundID(roundValue) != rootRoundID) {

--- a/internal/service/room/realtime/goal_continuation.go
+++ b/internal/service/room/realtime/goal_continuation.go
@@ -625,7 +625,7 @@ func (s *Service) releaseActiveGoalCollaborationSources(
 	if s == nil || roundValue == nil || binding == nil {
 		return
 	}
-	for _, candidateRound := range s.rounds.snapshot() {
+	for _, candidateRound := range s.roundsRegistry().snapshot() {
 		if candidateRound == nil || candidateRound == roundValue {
 			continue
 		}

--- a/internal/service/room/realtime/goal_runtime.go
+++ b/internal/service/room/realtime/goal_runtime.go
@@ -65,7 +65,7 @@ func (s *Service) QueueRoomContextualGuidanceInput(
 	sessionKey = strings.TrimSpace(sessionKey)
 	excludedAgentID = strings.TrimSpace(excludedAgentID)
 	targets := map[string]*activeRoomSlot{}
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil || strings.TrimSpace(roundValue.SessionKey) != sessionKey {
 			continue
 		}
@@ -130,7 +130,7 @@ func (s *Service) GoalObjectiveRevisionState(
 	roundID = strings.TrimSpace(roundID)
 	agentID = strings.TrimSpace(agentID)
 	var target *activeRoomSlot
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil || strings.TrimSpace(roundValue.SessionKey) != sessionKey {
 			continue
 		}
@@ -946,7 +946,7 @@ func (s *Service) finalizeCompletedRoomGoalUsage(
 	}
 	rounds := []*activeRoomRound{anchor}
 	seenRounds := map[*activeRoomRound]struct{}{anchor: {}}
-	for _, candidate := range s.rounds.snapshot() {
+	for _, candidate := range s.roundsRegistry().snapshot() {
 		if candidate == nil || strings.TrimSpace(candidate.SessionKey) != sessionKey {
 			continue
 		}
@@ -1118,7 +1118,7 @@ func (s *Service) bindRoomGoalUsage(sessionKey string, goalID string) {
 	if sessionKey == "" || goalID == "" {
 		return
 	}
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil || strings.TrimSpace(roundValue.SessionKey) != sessionKey {
 			continue
 		}
@@ -1159,7 +1159,7 @@ func (s *Service) roomGoalUsageSlotsForScope(
 		slots = append(slots, candidate)
 	}
 	appendSlot(origin)
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil {
 			continue
 		}
@@ -1637,7 +1637,7 @@ func (s *Service) clearRoomGoalUsage(sessionKey string) {
 	if sessionKey == "" {
 		return
 	}
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil || strings.TrimSpace(roundValue.SessionKey) != sessionKey {
 			continue
 		}
@@ -1655,7 +1655,7 @@ func (s *Service) beginRoomGoalUsageFinalizing(sessionKey string) {
 	if sessionKey == "" {
 		return
 	}
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil || strings.TrimSpace(roundValue.SessionKey) != sessionKey {
 			continue
 		}
@@ -1902,7 +1902,7 @@ func (s *Service) activeRoomGoalBlocker(
 	callerAgentID = strings.TrimSpace(callerAgentID)
 	callerRoundID = strings.TrimSpace(callerRoundID)
 
-	for _, roundValue := range s.rounds.snapshotConversation(conversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(conversationID) {
 		if roundValue == nil ||
 			strings.TrimSpace(roundValue.SessionKey) != sessionKey ||
 			strings.TrimSpace(roundValue.ConversationID) != conversationID {
@@ -1910,7 +1910,7 @@ func (s *Service) activeRoomGoalBlocker(
 		}
 		// public @ 已从模型输出解析，但尚未交接成目标 slot。
 		// 它挂在当前 shared Goal 的 Room round 上，清空或注册 slot 后自动解锁。
-		if s.rounds.hasPublicMentions(roundValue) {
+		if s.roundsRegistry().hasPublicMentions(roundValue) {
 			return "a Room public-mention wake has not started"
 		}
 		for _, slot := range roundValue.Slots {
@@ -1941,7 +1941,7 @@ func (s *Service) activeRoomGoalBlocker(
 			return fmt.Sprintf("agent %s still has an active Room slot", slotAgentID)
 		}
 	}
-	if s.rounds.hasPublicMentionsForConversation(conversationID) {
+	if s.roundsRegistry().hasPublicMentionsForConversation(conversationID) {
 		return "a Room public-mention wake has not started"
 	}
 	return ""

--- a/internal/service/room/realtime/guidance_input.go
+++ b/internal/service/room/realtime/guidance_input.go
@@ -36,9 +36,9 @@ func (s *Service) roomSlotGuidanceHook(
 			}
 		}
 		if roundValue != nil {
-			s.rounds.bindSlot(slot, roundValue)
+			s.roundsRegistry().bindSlot(slot, roundValue)
 		} else {
-			s.rounds.bindSlotToConversation(slot, location.ConversationID)
+			s.roundsRegistry().bindSlotToConversation(slot, location.ConversationID)
 		}
 		if s.hasPendingRoomSlotGuidance(slot) {
 			return sdkhook.Output{}, nil
@@ -172,14 +172,14 @@ func (s *Service) rememberRoomSlotGuidance(
 	if slot == nil || len(items) == 0 {
 		return pendingRoomGuidance{}
 	}
-	s.rounds.bindSlotToConversation(slot, location.ConversationID)
+	s.roundsRegistry().bindSlotToConversation(slot, location.ConversationID)
 	pending := pendingRoomGuidance{location: location, items: slices.Clone(items)}
-	s.rounds.putGuidance(slot, pending)
+	s.roundsRegistry().putGuidance(slot, pending)
 	return pending
 }
 
 func (s *Service) hasPendingRoomSlotGuidance(slot *activeRoomSlot) bool {
-	return s.rounds.hasGuidance(slot)
+	return s.roundsRegistry().hasGuidance(slot)
 }
 
 func (s *Service) hasInFlightRoomGuidance(itemID string) bool {
@@ -187,7 +187,7 @@ func (s *Service) hasInFlightRoomGuidance(itemID string) bool {
 	if itemID == "" {
 		return false
 	}
-	for _, pending := range s.rounds.guidanceSnapshot() {
+	for _, pending := range s.roundsRegistry().guidanceSnapshot() {
 		if slices.ContainsFunc(pending.items, func(item protocol.InputQueueItem) bool { return item.ID == itemID }) {
 			return true
 		}
@@ -229,7 +229,7 @@ func (s *Service) acknowledgeRoomSlotGuidanceLocked(
 	if slot == nil {
 		return nil
 	}
-	pending, ok := s.rounds.loadGuidance(slot)
+	pending, ok := s.roundsRegistry().loadGuidance(slot)
 	if !ok {
 		return nil
 	}
@@ -241,7 +241,7 @@ func (s *Service) acknowledgeRoomSlotGuidanceLocked(
 		return err
 	}
 	if len(claimed) != len(pending.items) {
-		s.rounds.deleteGuidance(slot)
+		s.roundsRegistry().deleteGuidance(slot)
 		return nil
 	}
 	if roundValue != nil && roundValue.Context != nil {
@@ -256,7 +256,7 @@ func (s *Service) acknowledgeRoomSlotGuidanceLocked(
 				restored, restoreErr := s.restoreRoomSlotGuidance(pending.location, claimed)
 				if restoreErr == nil {
 					pending.items = restored
-					s.rounds.putGuidance(slot, pending)
+					s.roundsRegistry().putGuidance(slot, pending)
 				}
 				return errors.Join(err, restoreErr)
 			}
@@ -266,7 +266,7 @@ func (s *Service) acknowledgeRoomSlotGuidanceLocked(
 				restored, restoreErr := s.restoreRoomSlotGuidance(pending.location, claimed)
 				if restoreErr == nil {
 					pending.items = restored
-					s.rounds.putGuidance(slot, pending)
+					s.roundsRegistry().putGuidance(slot, pending)
 				}
 				return errors.Join(
 					errors.New("Goal collaboration handoff cannot be acknowledged as ordinary Room guidance"),
@@ -277,13 +277,13 @@ func (s *Service) acknowledgeRoomSlotGuidanceLocked(
 				restored, restoreErr := s.restoreRoomSlotGuidance(pending.location, claimed)
 				if restoreErr == nil {
 					pending.items = restored
-					s.rounds.putGuidance(slot, pending)
+					s.roundsRegistry().putGuidance(slot, pending)
 				}
 				return errors.Join(err, restoreErr)
 			}
 		}
 	}
-	s.rounds.deleteGuidance(slot)
+	s.roundsRegistry().deleteGuidance(slot)
 	if roundValue != nil && roundValue.Context != nil {
 		if err = s.broadcastRoomInputQueueSnapshot(ctx, roundValue.SessionKey, roundValue.Context); err != nil {
 			s.loggerFor(ctx).Warn("广播 Room 引导队列消费快照失败",
@@ -316,7 +316,7 @@ func (s *Service) forgetRoomSlotGuidance(slot *activeRoomSlot) {
 	sessionKey, conversationID := roomSlotDispatchContext(nil, slot)
 	lease := s.lockRoomDispatch(sessionKey, conversationID)
 	defer lease.Unlock()
-	s.rounds.deleteGuidance(slot)
+	s.roundsRegistry().deleteGuidance(slot)
 }
 
 func roomSlotDispatchContext(roundValue *activeRoomRound, slot *activeRoomSlot) (string, string) {

--- a/internal/service/room/realtime/interrupt.go
+++ b/internal/service/room/realtime/interrupt.go
@@ -110,7 +110,7 @@ func (s *Service) collectRoundTargets(
 ) []interruptTarget {
 	targets := make([]interruptTarget, 0)
 	seen := make(map[string]struct{})
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil || !matcher(roundValue) {
 			continue
 		}
@@ -128,7 +128,7 @@ func (s *Service) collectSlotTargets(
 ) []interruptTarget {
 	targets := make([]interruptTarget, 0)
 	seen := make(map[string]struct{})
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue == nil {
 			continue
 		}
@@ -195,7 +195,7 @@ func (s *Service) interruptRound(
 
 func (s *Service) activeRoundsForSession(sessionKey string) []*activeRoomRound {
 	result := make([]*activeRoomRound, 0)
-	for _, roundValue := range s.rounds.snapshot() {
+	for _, roundValue := range s.roundsRegistry().snapshot() {
 		if roundValue != nil && roundValue.SessionKey == sessionKey {
 			result = append(result, roundValue)
 		}
@@ -208,11 +208,11 @@ func (s *Service) findActiveSlotByAgentRoundID(sessionKey string, agentRoundID s
 	if agentRoundID == "" {
 		return nil, nil
 	}
-	return s.rounds.findSlotByAgentRound(sessionKey, agentRoundID)
+	return s.roundsRegistry().findSlotByAgentRound(sessionKey, agentRoundID)
 }
 
 func (s *Service) findActiveRoundByRoundID(sessionKey string, roundID string) *activeRoomRound {
-	return s.rounds.findByRoundID(sessionKey, roundID)
+	return s.roundsRegistry().findByRoundID(sessionKey, roundID)
 }
 
 func (s *Service) findActiveSlot(sessionKey string, msgID string) (*activeRoomRound, *activeRoomSlot) {
@@ -220,7 +220,7 @@ func (s *Service) findActiveSlot(sessionKey string, msgID string) (*activeRoomRo
 	if msgID == "" {
 		return nil, nil
 	}
-	return s.rounds.findSlot(sessionKey, msgID)
+	return s.roundsRegistry().findSlot(sessionKey, msgID)
 }
 
 func (s *Service) interruptActiveSlot(

--- a/internal/service/room/realtime/public_mentions.go
+++ b/internal/service/room/realtime/public_mentions.go
@@ -216,14 +216,14 @@ func (s *Service) enqueuePublicMentionWake(roundValue *activeRoomRound, wake pub
 	if roundValue == nil || strings.TrimSpace(wake.TargetAgentID) == "" {
 		return
 	}
-	s.rounds.enqueuePublicMention(roundValue, wake)
+	s.roundsRegistry().enqueuePublicMention(roundValue, wake)
 }
 
 func (s *Service) takePublicMentionWakes(roundValue *activeRoomRound) []publicMentionWake {
 	if roundValue == nil {
 		return nil
 	}
-	return s.rounds.takePublicMentions(roundValue)
+	return s.roundsRegistry().takePublicMentions(roundValue)
 }
 
 func (s *Service) startQueuedPublicMentionWakes(ctx context.Context, roundValue *activeRoomRound) bool {

--- a/internal/service/room/realtime/public_message.go
+++ b/internal/service/room/realtime/public_message.go
@@ -339,7 +339,7 @@ func (s *Service) goalCollaborationBindingForActiveRound(
 	conversationID = strings.TrimSpace(conversationID)
 	sourceAgentID = strings.TrimSpace(sourceAgentID)
 	rootRoundID = strings.TrimSpace(rootRoundID)
-	for _, roundValue := range s.rounds.snapshotConversation(conversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(conversationID) {
 		if roundValue == nil || strings.TrimSpace(roundValue.ConversationID) != conversationID {
 			continue
 		}
@@ -402,7 +402,7 @@ func (s *Service) resolveRoomMessageCausality(
 	normalizedSourceAgentID := strings.TrimSpace(sourceAgentID)
 	normalizedRootRoundID := strings.TrimSpace(rootRoundID)
 
-	for _, roundValue := range s.rounds.snapshotConversation(normalizedConversationID) {
+	for _, roundValue := range s.roundsRegistry().snapshotConversation(normalizedConversationID) {
 		if roundValue == nil || strings.TrimSpace(roundValue.ConversationID) != normalizedConversationID {
 			continue
 		}

--- a/internal/service/room/realtime/service.go
+++ b/internal/service/room/realtime/service.go
@@ -192,7 +192,7 @@ type Service struct {
 	// goalUsageRetryBaseDelay 为零时使用生产退避；测试只调整时钟尺度。
 	goalUsageRetryBaseDelay time.Duration
 
-	rounds              roomRoundRegistry
+	rounds              *roomRoundRegistry
 	goalUsageScopeLocks roomGoalUsageScopeLockRegistry
 	wakeTimers          *roomWakeTimerRegistry
 }
@@ -463,7 +463,7 @@ func (s *Service) notifyRoomEventObserver(ctx context.Context, sessionKey string
 	if strings.TrimSpace(roundID) == "" {
 		return
 	}
-	roundValue := s.rounds.findByRoundID(sessionKey, roundID)
+	roundValue := s.roundsRegistry().findByRoundID(sessionKey, roundID)
 	var observer RoomEventObserver
 	if roundValue != nil {
 		observer = roundValue.EventObserver


### PR DESCRIPTION
Fixes #232\n\n将 "roomRoundRegistry" 的构造与持有统一改为指针，避免按值返回/复制时复制内嵌的 "sync.RWMutex"，从而消除 go vet copylocks 警告并避免未来潜在的数据竞争。\n\n变更要点：\n- newRoomRoundRegistry / newRoomRoundRegistryFromRounds 返回 *roomRoundRegistry\n- Service.rounds 字段改为 *roomRoundRegistry\n- 新增 roundsRegistry() accessor，对测试里未显式初始化 rounds 的 &Service{} 做惰性初始化\n- 全包统一通过 roundsRegistry() 访问 rounds\n\n验证：\n- go build ./internal/service/room/realtime/... ✅\n- go vet ./internal/service/room/realtime/... ✅\n- go test -count=1 ./internal/service/room/realtime/... ✅