### PR TITLE
fix: #235 Build regression: internal/runtime/client.go references undefined bridge.CapabilityMessageExecutionPolicy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/larksuite/oapi-sdk-go/v3 v3.9.2
-	github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.29
+	github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.30-0.20260821083757-75cbb4960fdd
 	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pressly/goose/v3 v3.27.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6B
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.29 h1:apEURHnaFBaMM6JumAQsDj+Bb2MmLNtTC3OwyPb3xww=
-github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.29/go.mod h1:vrO/rqDQJM2orurZpB49MfPX4LjSNlb6DQZAmELJw1Y=
+github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.30-0.20260821083757-75cbb4960fdd h1:cBC7MavVhg0fv+lLcpf/CV6pK7Q85bSRZvVJ6E/D+O4=
+github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.30-0.20260821083757-75cbb4960fdd/go.mod h1:vrO/rqDQJM2orurZpB49MfPX4LjSNlb6DQZAmELJw1Y=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1 h1:Lb/Uzkiw2Ugt2Xf03J5wmv81PdkYOiWbI8CNBi1boC8=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1/go.mod h1:ln3IqPYYocZbYvl9TAOrG/cxGR9xcn4pnZRLdCTEGEU=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=


### PR DESCRIPTION
## 问题

`main` 上 `go build ./...` / `go vet ./...` 失败：提交 8e2c7a98d 引用了 `bridge.CapabilityMessageExecutionPolicy` 以及 `protocol.OutboundMessageOptions` 的 `ToolAccess` / `MaxOutputTokens` / `MessageUUID` 字段，但 `go.mod` 固定的 bridge v0.1.29 尚未包含这些符号（上游已提交、未发版）。

## 修复（issue 建议方向 1：治本）

将 `github.com/nexus-research-lab/nexus-agent-sdk-bridge` 从 v0.1.29 升级到 main 分支伪版本 `v0.1.30-0.20260821083757-75cbb4960fdd`，该版本已包含：

- `client.CapabilityMessageExecutionPolicy = "message_execution_policy"`
- `protocol.OutboundMessageOptions.ToolAccess` / `MaxOutputTokens` / `MessageUUID`

与 #222 的修复方式一致（同样使用 bridge main 分支伪版本）。

## 验证

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -count=1 ./internal/runtime/... ./internal/service/dm/...` ✅ 全部通过

Closes #235