### PR TITLE
fix: #238 安全回归测试 TestSafeMessageDetailImageMediaType 在无关 commit 97d247c45 中被误删

### DIFF
--- a/internal/handler/agent/session_message_detail_test.go
+++ b/internal/handler/agent/session_message_detail_test.go
@@ -1,0 +1,17 @@
+// INPUT: canonical history 中不可信的图片 MIME 声明。
+// OUTPUT: detail 响应只保留安全 raster MIME，其他类型降级为 octet-stream。
+// POS: 大图片 HTTP 响应的内容类型安全回归测试。
+package agent
+
+import "testing"
+
+func TestSafeMessageDetailImageMediaType(t *testing.T) {
+	if got := safeMessageDetailImageMediaType(" IMAGE/PNG "); got != "image/png" {
+		t.Fatalf("png MIME = %q", got)
+	}
+	for _, value := range []string{"image/svg+xml", "text/html", "image/png\r\nX-Test: bad"} {
+		if got := safeMessageDetailImageMediaType(value); got != "application/octet-stream" {
+			t.Fatalf("unsafe MIME %q = %q", value, got)
+		}
+	}
+}


### PR DESCRIPTION
## 修复内容

恢复在 97d247c45（Windows WebView2 / state root 迁移修复，与本测试无关）中被误删的 17 行安全回归测试文件 `internal/handler/agent/session_message_detail_test.go`。

测试内容从 `97d247c45^` 原样还原，覆盖：

- 合法输入归一化：`" IMAGE/PNG "` → `image/png`
- 危险类型降级：`image/svg+xml`、`text/html` → `application/octet-stream`
- CRLF 注入尝试 → `application/octet-stream`

## 验证

- `go vet ./internal/handler/agent/` 通过
- `go test ./internal/handler/agent/ -run TestSafeMessageDetailImageMediaType -v` 通过

Fixes #238