### PR TITLE
fix: #237 CI: macOS Desktop Build 连续失败 — hdiutil detach force 路径无重试，EBUSY(16) 退出

### DIFF
--- a/scripts/desktop/package-macos-app.sh
+++ b/scripts/desktop/package-macos-app.sh
@@ -405,6 +405,19 @@ case "${ARTIFACT_FORMAT}" in
         fi
         sleep "${attempt}"
       done
+      # Force detach can also hit transient EBUSY (e.g. diskimages-helper
+      # still holding the volume after the AppleScript/Finder styling step).
+      # Retry the force path with backoff instead of failing the build on
+      # a single attempt.
+      for attempt in 1 2 3; do
+        if hdiutil detach -force "${device}" >/dev/null 2>&1; then
+          return 0
+        fi
+        sleep "$((attempt * 2))"
+      done
+      # Final attempt: keep stderr visible and dump volume state so CI logs
+      # show which process still holds the device instead of a bare EBUSY.
+      hdiutil info | grep -A5 "${device}" >&2 || true
       hdiutil detach -force "${device}" >/dev/null
     }
     cleanup_dmg_mount() {


### PR DESCRIPTION
## 修复内容

main 分支连续两次 `macOS Desktop Build` 在 `Validate macOS Intel build, smoke, and package` 步骤失败：

```
hdiutil: couldn't eject "disk4" - Resource busy
##[error]Process completed with exit code 16.
```

根因：`d7cc2d945` 已为 `hdiutil create/convert` 加了 `retry_hdiutil` 重试，但 `detach_dmg()` 的 force 路径只有单次尝试——3 次静默 detach 重试失败后，一发 force detach 失败即在 `set -e` 下以 EBUSY(16) 退出。占用来源大概率是 AppleScript 设置 DMG 背景后仍持有卷的 Finder / `diskimages-helper`。

## 改动（`scripts/desktop/package-macos-app.sh` `detach_dmg()`）

1. **force detach 进入重试循环**：3 次 force + backoff（2/4/6s），与普通 detach 的重试策略对齐；
2. **最终失败时输出诊断**：`hdiutil info | grep -A5 <device>` 打到 stderr，CI 日志能看到占用进程，而不是一行裸 `Resource busy`；
3. 最后一发 force detach 保持 stderr 可见、失败即退出（原行为不变）。

## 验证

- `bash -n scripts/desktop/package-macos-app.sh` 语法检查通过
- 本机无 shellcheck，未做静态检查（改动仅 13 行新增，无逻辑分支变更）

Fixes #237