### PR TITLE
fix: #241 【发布阻断】Computer Use 提交遗漏 web/src/lib/api/settings/computer-use-api.ts，前端 typecheck 与 build 均失败

### DIFF
--- a/web/src/features/settings/computer-use/computer-use-settings-section.tsx
+++ b/web/src/features/settings/computer-use/computer-use-settings-section.tsx
@@ -16,6 +16,7 @@ import {
   startComputerUseApi,
   stopComputerUseApi,
   type ComputerUseDoctorReport,
+  type ComputerUseSidecarState,
   type ComputerUseStatus,
   updateComputerUseApi,
 } from "@/lib/api/settings/computer-use-api";
@@ -125,6 +126,13 @@ export function ComputerUseSettingsSection() {
   const packageStatus = status?.package;
   const sidecar = status?.sidecar;
   const ready = sidecar?.state === "ready";
+  const sidecarStateLabels: Record<ComputerUseSidecarState, string> = {
+    stopped: t("settings.computer_use.state_stopped"),
+    starting: t("settings.computer_use.state_starting"),
+    ready: t("settings.computer_use.state_ready"),
+    stopping: t("settings.computer_use.state_stopping"),
+    failed: t("settings.computer_use.state_failed"),
+  };
 
   return (
     <div className={`${WORKSPACE_CONTENT_PAGE_CLASS_NAME} flex flex-col`}>
@@ -158,7 +166,7 @@ export function ComputerUseSettingsSection() {
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-compact">
             <StatusItem label={t("settings.computer_use.package_label")} value={packageStatus?.installed ? `v${packageStatus.version ?? "?"}` : t("settings.computer_use.not_installed")} />
             <StatusItem label={t("settings.computer_use.platform_label")} value={packageStatus ? `${packageStatus.platform} / ${packageStatus.architecture}` : "—"} />
-            <StatusItem label={t("settings.computer_use.runtime_label")} value={sidecar ? t(`settings.computer_use.state_${sidecar.state}`) : "—"} />
+            <StatusItem label={t("settings.computer_use.runtime_label")} value={sidecar ? sidecarStateLabels[sidecar.state] ?? "—" : "—"} />
           </div>
 
           <div className="mt-4 flex flex-wrap gap-2">

--- a/web/src/lib/api/settings/computer-use-api.ts
+++ b/web/src/lib/api/settings/computer-use-api.ts
@@ -1,0 +1,94 @@
+import { getAgentApiBaseUrl } from "@/config/runtime-endpoints";
+import { requestApi } from "@/lib/api/core/http";
+
+export type ComputerUsePackageSource = "managed" | "environment";
+
+export interface ComputerUsePackageStatus {
+  available: boolean;
+  installed: boolean;
+  source?: ComputerUsePackageSource;
+  version?: string;
+  target_version?: string;
+  protocol_version?: string;
+  platform: string;
+  architecture: string;
+  can_install: boolean;
+  can_update: boolean;
+  can_remove: boolean;
+  message?: string;
+}
+
+export type ComputerUseSidecarState = "stopped" | "starting" | "ready" | "stopping" | "failed";
+
+export interface ComputerUseSidecarStatus {
+  state: ComputerUseSidecarState;
+  epoch: number;
+  version?: string;
+  protocol_version?: string;
+  started_at?: string;
+  unexpected_exits: number;
+  last_error?: string;
+}
+
+export interface ComputerUseDoctorReport {
+  package: ComputerUsePackageStatus;
+  healthy: boolean;
+  runtime_version?: string;
+  protocol_version?: string;
+  platform?: string;
+  capabilities?: Record<string, unknown>;
+  permissions?: Record<string, string>;
+  message?: string;
+}
+
+export interface ComputerUseStatus {
+  enabled: boolean;
+  package: ComputerUsePackageStatus;
+  sidecar: ComputerUseSidecarStatus;
+  doctor?: ComputerUseDoctorReport;
+  next_actions?: string[];
+}
+
+const COMPUTER_USE_API_BASE_URL = `${getAgentApiBaseUrl()}/settings/computer-use`;
+
+export async function getComputerUseStatusApi(): Promise<ComputerUseStatus> {
+  return requestApi<ComputerUseStatus>(COMPUTER_USE_API_BASE_URL, {
+    method: "GET",
+  });
+}
+
+export async function installComputerUseApi(): Promise<ComputerUsePackageStatus> {
+  return requestApi<ComputerUsePackageStatus>(`${COMPUTER_USE_API_BASE_URL}/install`, {
+    method: "POST",
+  });
+}
+
+export async function updateComputerUseApi(): Promise<ComputerUsePackageStatus> {
+  return requestApi<ComputerUsePackageStatus>(`${COMPUTER_USE_API_BASE_URL}/update`, {
+    method: "POST",
+  });
+}
+
+export async function doctorComputerUseApi(): Promise<ComputerUseDoctorReport> {
+  return requestApi<ComputerUseDoctorReport>(`${COMPUTER_USE_API_BASE_URL}/doctor`, {
+    method: "POST",
+  });
+}
+
+export async function startComputerUseApi(): Promise<ComputerUseSidecarStatus> {
+  return requestApi<ComputerUseSidecarStatus>(`${COMPUTER_USE_API_BASE_URL}/start`, {
+    method: "POST",
+  });
+}
+
+export async function stopComputerUseApi(): Promise<{ stopped: boolean }> {
+  return requestApi<{ stopped: boolean }>(`${COMPUTER_USE_API_BASE_URL}/stop`, {
+    method: "POST",
+  });
+}
+
+export async function removeComputerUseApi(): Promise<{ removed: boolean }> {
+  return requestApi<{ removed: boolean }>(`${COMPUTER_USE_API_BASE_URL}/runtime`, {
+    method: "DELETE",
+  });
+}


### PR DESCRIPTION
## 关联 Issue

Fixes #241

## 问题

Computer Use 提交遗漏了 `web/src/lib/api/settings/computer-use-api.ts`，导致 main 分支前端 typecheck 与生产构建失败（发布阻断）。

## 修复内容

1. **补交缺失的 API 客户端** `web/src/lib/api/settings/computer-use-api.ts`
   - 对照后端路由（`internal/app/server/routes.go`：`/settings/computer-use`、`/install`、`/update`、`/doctor`、`/start`、`/stop`、DELETE `/runtime`）实现 7 个 API 函数
   - 类型定义（`ComputerUseStatus`、`ComputerUsePackageStatus`、`ComputerUseSidecarStatus`、`ComputerUseDoctorReport`、`ComputerUseSidecarState`）与 `internal/service/computeruse/model.go` 的 JSON 字段保持一致

2. **修复第二个 typecheck 错误**：`t(`settings.computer_use.state_${sidecar.state}`)` 动态模板 key 不满足 i18n key 联合类型
   - 改为显式 `Record<ComputerUseSidecarState, string>` 映射，未知 state 回退为 "—"，同时避免运行时显示原始 key

## 验证

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run build` ✅（原失败点）
- `pnpm run test` ✅ 395/395 通过

## 未包含

Issue 中建议的第 3 点（把 typecheck 加入 CI 必过检查）属于 CI 配置变更，超出本次修复范围，建议单独处理。