### PR TITLE
fix: #218 【软件测试建议】

### DIFF
--- a/internal/handler/shared/api.go
+++ b/internal/handler/shared/api.go
@@ -192,6 +192,8 @@ func IsClientMessageText(message string) bool {
 		strings.Contains(message, "不支持") ||
 		strings.Contains(message, "不能作为") ||
 		strings.Contains(message, "不能超过") ||
+		strings.Contains(message, "请先在") ||
+		strings.Contains(message, "仍使用") ||
 		strings.Contains(message, " is required") ||
 		strings.Contains(message, " must be ") ||
 		strings.Contains(message, "正在运行中")

--- a/internal/handler/shared/api_test.go
+++ b/internal/handler/shared/api_test.go
@@ -1,0 +1,20 @@
+package shared
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsClientMessageTextAllowsDefaultModelHint(t *testing.T) {
+	if !IsClientMessageText("默认模型仍使用 Provider kimi-code；请先在设置中切换默认模型") {
+		t.Fatal("包含具体操作指引的默认模型保护提示应被判定为客户端可展示文案")
+	}
+}
+
+func TestGatewayClientErrorDetailPreservesDefaultModelHint(t *testing.T) {
+	detail := "默认模型仍使用 Provider kimi-code；请先在设置中切换默认模型"
+	got := GatewayClientErrorDetail(http.StatusBadRequest, detail)
+	if got != detail {
+		t.Fatalf("BadRequest 下的默认模型保护提示应直接返回给客户端，got=%q want=%q", got, detail)
+	}
+}


### PR DESCRIPTION
Fixes #218.

## 修复内容

当用户尝试禁用某个 Provider，但该 Provider 的模型仍被设为默认对话模型时，后端会返回明确的引导文案：

> 默认模型仍使用 Provider `xxx`；请先在设置中切换默认模型

此前由于 `GatewayClientErrorDetail` 的客户端文案白名单未覆盖这类提示，前端收到 400 时统一显示为“请求参数错误”。本 PR 把 `请先在` 和 `仍使用` 加入白名单，使该业务提示能原样展示给用户。

## 验证

- `go test ./internal/handler/shared/...` 通过
- `./scripts/check-go-changed.sh` 通过（覆盖 4 个相关包）

## 未包含

Issue 中提到的测试体系建设和同类产品对比评估属于更广泛的工程决策，未在本修复范围内。