### PR TITLE
fix: #247 launcher: DM conversations never receive LastReplyPreview due to roomID-only guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored Launcher latest-reply previews for DM conversations while continuing to exclude external IM sessions.
 - Kept `nexusctl` exclusive to the main Agent by removing it from ordinary Agent and Room prompts, shared runtime PATH discovery, and shared Skills while retaining round-scoped `nexuscfg` and `nexus.command` capabilities.
 - Kept the browser extension folder visible after reopening the macOS installation windows instead of letting Chrome or Edge cover Finder as their extensions page finishes opening.
 - Stopped ordinary and managed turns from replaying completed Runtime Graph summaries into every model request; explicit Execution inspection still returns bounded successful history, while active failures, artifacts, WorkGraph, Trace, and audit projections remain available.

--- a/internal/service/launcher/bootstrap.go
+++ b/internal/service/launcher/bootstrap.go
@@ -120,7 +120,7 @@ func (s *Service) attachLatestReplyPreviews(
 	ctx context.Context,
 	items []BootstrapConversation,
 ) {
-	seenRoomIDs := make(map[string]struct{}, len(items))
+	seenPreviewKeys := make(map[string]struct{}, len(items))
 	for index := range items {
 		if ctx.Err() != nil {
 			return
@@ -128,16 +128,20 @@ func (s *Service) attachLatestReplyPreviews(
 		if isExternalLauncherConversation(items[index]) {
 			continue
 		}
-		roomID := strings.TrimSpace(items[index].RoomID)
-		if roomID == "" {
-			continue
-		}
-		if _, exists := seenRoomIDs[roomID]; exists {
-			continue
-		}
-		seenRoomIDs[roomID] = struct{}{}
-
 		sessionKey := previewSessionKey(items[index])
+		roomID := strings.TrimSpace(items[index].RoomID)
+		previewKey := roomID
+		if previewKey == "" {
+			previewKey = strings.TrimSpace(sessionKey)
+		}
+		if previewKey == "" {
+			continue
+		}
+		if _, exists := seenPreviewKeys[previewKey]; exists {
+			continue
+		}
+		seenPreviewKeys[previewKey] = struct{}{}
+
 		page, err := s.session.GetSessionMessagesPage(
 			ctx,
 			sessionKey,

--- a/internal/service/launcher/bootstrap_test.go
+++ b/internal/service/launcher/bootstrap_test.go
@@ -1,0 +1,116 @@
+package launcher
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/nexus-research-lab/nexus/internal/protocol"
+	sessionsvc "github.com/nexus-research-lab/nexus/internal/service/session"
+)
+
+type fakeLauncherSessionReader struct {
+	pages     map[string]*protocol.MessagePage
+	requested []string
+	limits    []int
+}
+
+func (f *fakeLauncherSessionReader) ListDirectorySessions(context.Context) ([]protocol.Session, error) {
+	return nil, nil
+}
+
+func (f *fakeLauncherSessionReader) GetSessionMessagesPage(
+	_ context.Context,
+	sessionKey string,
+	request sessionsvc.MessagePageRequest,
+) (*protocol.MessagePage, error) {
+	f.requested = append(f.requested, sessionKey)
+	f.limits = append(f.limits, request.Limit)
+	if page, ok := f.pages[sessionKey]; ok {
+		return page, nil
+	}
+	return &protocol.MessagePage{}, nil
+}
+
+func TestAttachLatestReplyPreviewsIncludesDMConversations(t *testing.T) {
+	sharedRoomKey := protocol.BuildRoomSharedSessionKey("conversation-room")
+	reader := &fakeLauncherSessionReader{
+		pages: map[string]*protocol.MessagePage{
+			"agent-session-dm": {
+				Items: []protocol.Message{
+					{
+						"role": "assistant",
+						"content": []any{
+							map[string]any{"type": "text", "text": "DM latest reply"},
+						},
+					},
+				},
+			},
+			sharedRoomKey: {
+				Items: []protocol.Message{
+					{
+						"role": "assistant",
+						"content": []any{
+							map[string]any{"type": "text", "text": "Room latest reply"},
+						},
+					},
+				},
+			},
+		},
+	}
+	service := &Service{session: reader}
+	items := []BootstrapConversation{
+		{
+			SessionKey: "agent-session-dm",
+			AgentID:    "agent-a",
+			RoomType:   protocol.RoomTypeDM,
+			Title:      "DM",
+		},
+		{
+			SessionKey:     "room-slot-a",
+			RoomID:         "room-1",
+			ConversationID: "conversation-room",
+			RoomType:       "room",
+			Title:          "Room",
+		},
+		{
+			SessionKey:     "room-slot-b",
+			RoomID:         "room-1",
+			ConversationID: "conversation-room",
+			RoomType:       "room",
+			Title:          "Room duplicate",
+		},
+		{
+			SessionKey:  "external-dm",
+			AgentID:     "agent-b",
+			RoomType:    protocol.RoomTypeDM,
+			ChannelType: protocol.SessionChannelDiscord,
+			Title:       "External DM",
+		},
+	}
+
+	service.attachLatestReplyPreviews(context.Background(), items)
+
+	if got := items[0].LastReplyPreview; got != "DM latest reply" {
+		t.Fatalf("DM preview = %q, want %q", got, "DM latest reply")
+	}
+	if got := items[1].LastReplyPreview; got != "Room latest reply" {
+		t.Fatalf("Room preview = %q, want %q", got, "Room latest reply")
+	}
+	if got := items[2].LastReplyPreview; got != "" {
+		t.Fatalf("duplicate Room preview = %q, want empty", got)
+	}
+	if got := items[3].LastReplyPreview; got != "" {
+		t.Fatalf("external conversation preview = %q, want empty", got)
+	}
+
+	wantRequests := []string{"agent-session-dm", sharedRoomKey}
+	if !reflect.DeepEqual(reader.requested, wantRequests) {
+		t.Fatalf("requested session keys = %#v, want %#v", reader.requested, wantRequests)
+	}
+	for _, limit := range reader.limits {
+		if limit != 2 {
+			t.Fatalf("message page limit = %d, want 2", limit)
+		}
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Launcher bootstrap skipped latest-reply preview loading for conversations without a Room ID, so DM conversations never received `last_reply_preview` in the sidebar.

## Why This Change Was Made

`attachLatestReplyPreviews` now chooses a preview dedupe key from the Room ID when present, otherwise from the DM session key. This keeps Room history deduped while allowing DM sessions to use the existing `previewSessionKey` path. External IM conversations remain excluded.

## User Impact

DM conversations in Launcher/sidebar now show the latest assistant reply preview like Room conversations do.

## Evidence

- `go test ./internal/service/launcher`
- `make check-go`

Fixes nexus-research-lab/nexus#247