### PR TITLE
chore(web): patch development toolchain dependency advisories

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -67,10 +67,10 @@
   },
   "pnpm": {
     "overrides": {
-      "postcss": ">=8.5.10",
+      "postcss": ">=8.5.23",
       "exceljs>tmp": "0.2.7",
       "exceljs>uuid": "11.1.1",
-      "js-yaml": "4.2.0",
+      "js-yaml": "^4.3.1",
       "@babel/core": "7.29.7",
       "brace-expansion@1": "^1.1.18",
       "brace-expansion@2": "^2.1.4"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
   exceljs>tmp: 0.2.7
   exceljs>uuid: 11.1.1
-  js-yaml: 4.2.0
+  js-yaml: ^4.3.1
   '@babel/core': 7.29.7
   brace-expansion@1: ^1.1.18
   brace-expansion@2: ^2.1.4
@@ -1818,8 +1818,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2211,8 +2211,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2333,8 +2333,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3081,7 +3081,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3289,7 +3289,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.17
       '@tailwindcss/oxide': 4.1.17
-      postcss: 8.5.15
+      postcss: 8.5.26
       tailwindcss: 4.1.17
 
   '@tanstack/react-virtual@3.13.23(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -4789,7 +4789,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5391,7 +5391,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -5510,9 +5510,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5707,7 +5707,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       lightningcss: 1.30.2
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.26
       rolldown: 1.0.0-beta.53(@emnapi/core@1.7.1)(@emnapi/runtime@1.7.1)
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Scope\n\nThe production dependency findings originally reported in #248 are already fixed on main by 9d9923b8b, and pnpm audit --prod currently reports zero findings.\n\nThis PR is a separate follow-up for the development/build toolchain. A full audit on current main reports six advisories (five high, one moderate) in js-yaml, PostCSS, and PostCSS's transitive nanoid dependency.\n\n## Changes\n\n- Raise the js-yaml override from 4.2.0 to ^4.3.1.\n- Raise the PostCSS override from >=8.5.10 to >=8.5.23.\n- Refresh pnpm-lock.yaml, resolving js-yaml 4.3.2, PostCSS 8.5.26, and nanoid 3.3.18.\n\n## Verification\n\n- pnpm install --frozen-lockfile\n- pnpm audit --prod: no known vulnerabilities\n- pnpm audit --audit-level moderate: no known vulnerabilities\n- pnpm run typecheck\n- pnpm run lint\n- pnpm run test: 205 tests passed\n- pnpm run build\n\nThe existing bundle-size warning is unchanged. This PR does not close #248; that production-scope issue is already complete.