### PR TITLE
fix: #252 test(skills): TestConcurrentVersionedRemoteImportsHaveSingleWinner intermittently fails with SQLITE_BUSY under go test ./...

### DIFF
--- a/internal/service/skills/catalog_mutation_test.go
+++ b/internal/service/skills/catalog_mutation_test.go
@@ -2,7 +2,6 @@ package skills
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -40,11 +39,7 @@ description: revision ` + string(rune('0'+current)) + `
 	cfg := newSkillsTestConfig(t)
 	cfg.SkillsSourceURLs = "Atomic|" + server.URL
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewServiceWithDB(cfg, db, agentService, workspaceService)
@@ -176,11 +171,7 @@ func TestCatalogVersionRejectsStaleRemoteImportAndSourceUpdate(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	cfg.SkillsSourceURLs = "Test|" + server.URL
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 	ctx := context.Background()
 	state, err := service.GetCatalogState(ctx)
@@ -246,11 +237,7 @@ func TestConcurrentVersionedRemoteImportsHaveSingleWinner(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	cfg.SkillsSourceURLs = "Race|" + server.URL
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 	state, err := service.GetCatalogState(context.Background())
 	if err != nil {

--- a/internal/service/skills/marketplace_external_test.go
+++ b/internal/service/skills/marketplace_external_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"database/sql"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -38,11 +37,7 @@ tags: [url]
 	cfg.SkillsAPIURL = ""
 	cfg.SkillsSourceURLs = "URL Test|" + server.URL + "/url-demo/SKILL.md"
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 
 	detail, err := service.ImportSkillURL(context.Background(), server.URL+"/url-demo/SKILL.md", externalManifest{
@@ -81,11 +76,7 @@ func TestPreviewAndImportSkillURLSupportBackslashZipEntries(t *testing.T) {
 	cfg.SkillsDefaultSourcesEnabled = false
 	cfg.SkillsSourceURLs = "Local Zip|" + server.URL + "/target-industry-customer-analysis.zip"
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 	downloadURL := server.URL + "/target-industry-customer-analysis.zip"
 
@@ -109,11 +100,7 @@ func TestPreviewAndImportSkillURLSupportBackslashZipEntries(t *testing.T) {
 func TestImportSkillsShClonesRepositoryAndSelectsRequestedSkill(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 	ctx := context.Background()
 
@@ -185,11 +172,7 @@ func TestValidateExternalURLCanonicalizesSkillsShDetailHost(t *testing.T) {
 func TestImportLocalPathPersistsPrivateSourceMetadata(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 	ctx := context.Background()
 
@@ -236,11 +219,7 @@ func TestImportLocalPathRejectsAuthenticatedHostPath(t *testing.T) {
 func TestGitImportAndUpdateImportedSkillsUseStoredMetadata(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 	ctx := context.Background()
 

--- a/internal/service/skills/marketplace_private_registry_test.go
+++ b/internal/service/skills/marketplace_private_registry_test.go
@@ -3,7 +3,6 @@ package skills
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -94,11 +93,7 @@ func TestPrivateRegistrySourceSearchImportAndUpdate(t *testing.T) {
 	cfg.SkillsAPIURL = ""
 	cfg.SkillsSourceURLs = "Public Test|" + server.URL + "/public-index.json"
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	service := NewServiceWithDB(cfg, db, nil, nil)
 	ctx := context.Background()
 	beforeCreate, err := service.GetCatalogState(ctx)

--- a/internal/service/skills/registry_test.go
+++ b/internal/service/skills/registry_test.go
@@ -1,7 +1,6 @@
 package skills
 
 import (
-	"database/sql"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -16,11 +15,7 @@ func TestServiceExternalSkillRegistryIsPrivatePerOwner(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
@@ -32,10 +27,10 @@ func TestServiceExternalSkillRegistryIsPrivatePerOwner(t *testing.T) {
 	sourceB := filepath.Join(t.TempDir(), "private-skill-b")
 	writeTestSkillDir(t, sourceA, "private-skill", "Owner A Skill", false)
 	writeTestSkillDir(t, sourceB, "private-skill", "Owner B Skill", false)
-	if _, err = service.ImportLocalPath(ctxA, sourceA); err != nil {
+	if _, err := service.ImportLocalPath(ctxA, sourceA); err != nil {
 		t.Fatalf("owner-a 导入 skill 失败: %v", err)
 	}
-	if _, err = service.ImportLocalPath(ctxB, sourceB); err != nil {
+	if _, err := service.ImportLocalPath(ctxB, sourceB); err != nil {
 		t.Fatalf("owner-b 导入 skill 失败: %v", err)
 	}
 	agentA, err := agentService.CreateAgent(ctxA, protocol.CreateRequest{Name: "Owner A Agent"})

--- a/internal/service/skills/service_test.go
+++ b/internal/service/skills/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nexus-research-lab/nexus/internal/infra/authctx"
 	agentsvc "github.com/nexus-research-lab/nexus/internal/service/agent"
 	workspacepkg "github.com/nexus-research-lab/nexus/internal/service/workspace"
+	"github.com/nexus-research-lab/nexus/internal/storage"
 	"github.com/nexus-research-lab/nexus/internal/storage/agentrepo"
 
 	_ "modernc.org/sqlite"
@@ -64,11 +65,7 @@ func TestServiceImportsAndEnablesSkill(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewService(cfg, agentService, workspaceService)
@@ -450,11 +447,7 @@ func TestBuiltinPlatformSkillStoresIDWithoutWorkspaceCopy(t *testing.T) {
 		t.Fatalf("初始化测试平台 Skill 失败: %v", err)
 	}
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewService(cfg, agentService, workspaceService)
@@ -549,11 +542,7 @@ func TestAgentWorkspaceSkillIsPrivateAndEnabledByDefault(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewService(cfg, agentService, workspaceService)
@@ -644,11 +633,7 @@ func TestVersionedSkillMutationPreservesConcurrentAgentOptions(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewService(cfg, agentService, workspaceService)
@@ -843,11 +828,7 @@ func TestUserGlobalSkillUsesGlobalAgentBinding(t *testing.T) {
 	cfg.AppMode = "desktop"
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewService(cfg, agentService, workspaceService)
@@ -863,7 +844,7 @@ func TestUserGlobalSkillUsesGlobalAgentBinding(t *testing.T) {
 		"用户全局 Skill",
 		false,
 	)
-	if err = workspacepkg.EnsureHostSkillLibrary(cfg); err != nil {
+	if err := workspacepkg.EnsureHostSkillLibrary(cfg); err != nil {
 		t.Fatalf("同步宿主 Skill 投影失败: %v", err)
 	}
 
@@ -1023,11 +1004,7 @@ func TestAgentWorkspaceSkillShadowsSameNamedUserGlobalSkill(t *testing.T) {
 	cfg.AppMode = "desktop"
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewService(cfg, agentService, workspaceService)
@@ -1038,7 +1015,7 @@ func TestAgentWorkspaceSkillShadowsSameNamedUserGlobalSkill(t *testing.T) {
 	t.Setenv("NEXUS_APP_MODE", "desktop")
 	hostSkillRoot := filepath.Join(home, ".agents", "skills", "same-name-skill")
 	writeTestSkillDir(t, hostSkillRoot, "same-name-skill", "用户全局版本", false)
-	if err = workspacepkg.EnsureHostSkillLibrary(cfg); err != nil {
+	if err := workspacepkg.EnsureHostSkillLibrary(cfg); err != nil {
 		t.Fatalf("同步宿主 Skill 投影失败: %v", err)
 	}
 
@@ -1221,11 +1198,7 @@ func TestUpdateSingleSkillUsesSharedUserSource(t *testing.T) {
 	cfg := newSkillsTestConfig(t)
 	migrateSkillsSQLite(t, cfg.DatabaseURL)
 
-	db, err := sql.Open("sqlite", cfg.DatabaseURL)
-	if err != nil {
-		t.Fatalf("打开测试数据库失败: %v", err)
-	}
-	defer func() { _ = db.Close() }()
+	db := openSkillsTestDB(t, cfg)
 	agentService := agentsvc.NewService(cfg, agentrepo.NewSQLRepository("sqlite", db))
 	workspaceService := workspacepkg.NewService(cfg, agentService)
 	service := NewServiceWithDB(cfg, db, agentService, workspaceService)
@@ -1386,6 +1359,16 @@ func newSkillsTestConfig(t *testing.T) config.Config {
 		DatabaseURL:               filepath.Join(root, "nexus.db"),
 		ConnectorOAuthRedirectURI: "http://localhost:3000/capability/connectors",
 	}
+}
+
+func openSkillsTestDB(t *testing.T, cfg config.Config) *sql.DB {
+	t.Helper()
+	db, err := storage.OpenDB(cfg)
+	if err != nil {
+		t.Fatalf("打开测试数据库失败: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
 }
 
 func migrateSkillsSQLite(t *testing.T, databaseURL string) {


### PR DESCRIPTION
Fixes #252\n\n- Centralizes SQLite test connection creation in , which delegates to  so skills tests use the same  and  settings as production connections.\n- Replaces all raw  calls in the  test package.\n- Removes now-unused  imports in the affected test files.\n\nVerified with:\n- go test -count=50 -p=4 ./internal/service/skills -run TestConcurrentVersionedRemoteImportsHaveSingleWinner\n- go test -count=3 -p=4 ./internal/service/skills\n- go vet ./internal/service/skills\n\nDo not merge automatically — awaiting code review.