### PR TITLE
fix: #254 test(storage/orchestration): parallel tests data race on goose.SetDialect global store

### DIFF
--- a/internal/storage/orchestration/completion_audit_test.go
+++ b/internal/storage/orchestration/completion_audit_test.go
@@ -136,9 +136,7 @@ func TestCompletionAuditMigrationBackfillsLegacyAcceptedReview(t *testing.T) {
 
 	// Roll only the new receipt migration back to reproduce the exact legacy
 	// state: accepted active WorkGraph, no durable completion-audit table.
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.DownTo(
 		repository.db,
 		orchestrationMigrationDir(t, "sqlite"),

--- a/internal/storage/orchestration/dialect_test.go
+++ b/internal/storage/orchestration/dialect_test.go
@@ -1,0 +1,26 @@
+package orchestration
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// goose.SetDialect writes an unsynchronized package-level global in goose v3,
+// which data-races when t.Parallel() tests run migrations concurrently.
+// Set it once per test package instead of in every test helper.
+var (
+	gooseDialectOnce sync.Once
+	gooseDialectErr  error
+)
+
+func ensureGooseSQLiteDialect(t *testing.T) {
+	t.Helper()
+	gooseDialectOnce.Do(func() {
+		gooseDialectErr = goose.SetDialect("sqlite3")
+	})
+	if gooseDialectErr != nil {
+		t.Fatal(gooseDialectErr)
+	}
+}

--- a/internal/storage/orchestration/goal_confirmation_test.go
+++ b/internal/storage/orchestration/goal_confirmation_test.go
@@ -217,9 +217,7 @@ func TestGoalConfirmationMigrationBackfillsOnlyExactPendingBinding(t *testing.T)
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.UpTo(db, orchestrationMigrationDir(t, "sqlite"), 87); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/orchestration/goal_orphan_binding_migration_test.go
+++ b/internal/storage/orchestration/goal_orphan_binding_migration_test.go
@@ -20,9 +20,7 @@ func TestGoalOnlyOrphanBindingMigrationReleasesOnlyUnboundHalfCommit(t *testing.
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.UpTo(db, orchestrationMigrationDir(t, "sqlite"), 104); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/orchestration/repository_test.go
+++ b/internal/storage/orchestration/repository_test.go
@@ -1709,9 +1709,7 @@ func newRepositoryTestStore(t *testing.T) *Repository {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.Up(migrationDB, "../../../db/migrations/sqlite"); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/queueadmission/dialect_test.go
+++ b/internal/storage/queueadmission/dialect_test.go
@@ -1,0 +1,26 @@
+package queueadmission
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// goose.SetDialect writes an unsynchronized package-level global in goose v3,
+// which data-races when t.Parallel() tests run migrations concurrently.
+// Set it once per test package instead of in every test helper.
+var (
+	gooseDialectOnce sync.Once
+	gooseDialectErr  error
+)
+
+func ensureGooseSQLiteDialect(t *testing.T) {
+	t.Helper()
+	gooseDialectOnce.Do(func() {
+		gooseDialectErr = goose.SetDialect("sqlite3")
+	})
+	if gooseDialectErr != nil {
+		t.Fatal(gooseDialectErr)
+	}
+}

--- a/internal/storage/queueadmission/repository_test.go
+++ b/internal/storage/queueadmission/repository_test.go
@@ -288,9 +288,7 @@ func newQueueAdmissionTestRepository(t *testing.T) (*Repository, *sql.DB) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.Up(db, "../../../db/migrations/sqlite"); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/roomrepo/concurrency_test.go
+++ b/internal/storage/roomrepo/concurrency_test.go
@@ -225,9 +225,7 @@ func newConcurrentRoomRepositories(
 
 	databaseURL := t.TempDir() + "/concurrent-room.db"
 	dbA := openConcurrentRoomDB(t, databaseURL)
-	if err := goose.SetDialect("sqlite3"); err != nil {
-		t.Fatalf("设置 goose 方言失败: %v", err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err := goose.Up(dbA, roomrepoMigrationDir(t)); err != nil {
 		t.Fatalf("执行 migration 失败: %v", err)
 	}

--- a/internal/storage/roomrepo/dialect_test.go
+++ b/internal/storage/roomrepo/dialect_test.go
@@ -1,0 +1,26 @@
+package roomrepo
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// goose.SetDialect writes an unsynchronized package-level global in goose v3,
+// which data-races when t.Parallel() tests run migrations concurrently.
+// Set it once per test package instead of in every test helper.
+var (
+	gooseDialectOnce sync.Once
+	gooseDialectErr  error
+)
+
+func ensureGooseSQLiteDialect(t *testing.T) {
+	t.Helper()
+	gooseDialectOnce.Do(func() {
+		gooseDialectErr = goose.SetDialect("sqlite3")
+	})
+	if gooseDialectErr != nil {
+		t.Fatalf("设置 goose 方言失败: %v", gooseDialectErr)
+	}
+}

--- a/internal/storage/roomrepo/migration_test.go
+++ b/internal/storage/roomrepo/migration_test.go
@@ -21,9 +21,7 @@ func TestConversationDraftMigrationPreservesLegacyDataAndAddsUniqueDraft(t *test
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	migrationDir := roomRepositoryMigrationDir(t, "sqlite")
 	if err = goose.UpTo(db, migrationDir, 55); err != nil {
 		t.Fatal(err)

--- a/internal/storage/roomrepo/versions_test.go
+++ b/internal/storage/roomrepo/versions_test.go
@@ -24,9 +24,7 @@ func TestRoomConfigurationVersionsPersistAndAdvance(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatalf("设置 goose 方言失败: %v", err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.Up(db, roomrepoMigrationDir(t)); err != nil {
 		t.Fatalf("执行 migration 失败: %v", err)
 	}

--- a/internal/storage/workgraphworkflow/dialect_test.go
+++ b/internal/storage/workgraphworkflow/dialect_test.go
@@ -1,0 +1,26 @@
+package workgraphworkflow
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// goose.SetDialect writes an unsynchronized package-level global in goose v3,
+// which data-races when t.Parallel() tests run migrations concurrently.
+// Set it once per test package instead of in every test helper.
+var (
+	gooseDialectOnce sync.Once
+	gooseDialectErr  error
+)
+
+func ensureGooseSQLiteDialect(t *testing.T) {
+	t.Helper()
+	gooseDialectOnce.Do(func() {
+		gooseDialectErr = goose.SetDialect("sqlite3")
+	})
+	if gooseDialectErr != nil {
+		t.Fatal(gooseDialectErr)
+	}
+}

--- a/internal/storage/workgraphworkflow/repository_test.go
+++ b/internal/storage/workgraphworkflow/repository_test.go
@@ -20,9 +20,7 @@ func TestRepositoryPersistsWorkflowAggregateAndOwnerScope(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.Up(db, "../../../db/migrations/sqlite"); err != nil {
 		t.Fatal(err)
 	}
@@ -82,9 +80,7 @@ func TestRepositoryPersistsRecoverableDraftVersionsAndSelection(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if err = goose.SetDialect("sqlite3"); err != nil {
-		t.Fatal(err)
-	}
+	ensureGooseSQLiteDialect(t)
 	if err = goose.Up(db, "../../../db/migrations/sqlite"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## 关联 issue

Fixes #254

## 改动说明

`goose.SetDialect` 会写入 goose v3 包级无同步保护的全局变量，`runtime_graph_test.go` 中 8 个 `t.Parallel()` 测试并发执行 `newRepositoryTestStore` 时触发 `WARNING: DATA RACE`。

按 issue 建议方案 2（最小改动止血）处理：

- 在 orchestration、roomrepo、workgraphworkflow、queueadmission 四个测试包中新增 `ensureGooseSQLiteDialect(t)` helper（`sync.Once` 保护，每进程只设置一次方言）。
- 替换所有测试 helper / 测试函数中的 `goose.SetDialect("sqlite3")` 重复调用（共 9 处）。

未采用方案 1（`goose.NewProvider` 实例化 API）以保持最小 diff；全局状态仍存在但不再并发写。后续如需根治可另行迁移。

## 验证

```
go test -race -count=1 -timeout 15m ./internal/storage/orchestration
# ok  github.com/nexus-research-lab/nexus/internal/storage/orchestration  469.820s
```

`go vet` 四个改动包均通过。