### PR TITLE
fix: #256 Build regression: internal/service/room/realtime references undefined SkipAutoMemory in nexus-agent-sdk-bridge v0.1.31

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/larksuite/oapi-sdk-go/v3 v3.11.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
-	github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.31
+	github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.32-0.20260901065947-dca4f84ef938
 	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.2-beta.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pressly/goose/v3 v3.27.0

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/u
 github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.31 h1:2XkJZGPL0k7NYwOS0sijAYM9JoiCQER4zkepZCMOB78=
-github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.31/go.mod h1:vrO/rqDQJM2orurZpB49MfPX4LjSNlb6DQZAmELJw1Y=
+github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.32-0.20260901065947-dca4f84ef938 h1:phriVPXcyisrqBiV5dkpZaFT5e8xTKTR0uSw6E7dYDY=
+github.com/nexus-research-lab/nexus-agent-sdk-bridge v0.1.32-0.20260901065947-dca4f84ef938/go.mod h1:vrO/rqDQJM2orurZpB49MfPX4LjSNlb6DQZAmELJw1Y=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.2-beta.1 h1:5WwR5TV6A12taXMH7SggT8yCMMJMF9jWE7Wj+4AuHck=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.2-beta.1/go.mod h1:ln3IqPYYocZbYvl9TAOrG/cxGR9xcn4pnZRLdCTEGEU=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=


### PR DESCRIPTION
## What Problem This Solves

Main branch fails to compile: `internal/service/room/realtime/execution.go` references `OutboundMessageOptions.SkipAutoMemory`, which does not exist in the pinned `nexus-agent-sdk-bridge v0.1.31` tag. This breaks `go build`, `go vet`, `make check-go-full`, and all Go tests on main.

## Why This Change Was Made

Commit 3160a6f (`:bug: Limit Room AutoMemory to user turns`) uses `SkipAutoMemory`, which exists on the bridge `main` branch but has not been tagged yet. The recommended long-term fix is a new bridge tag (e.g. v0.1.32); until that exists, this PR pins the module to the verified main-branch commit `dca4f84ef938` via pseudo-version `v0.1.32-0.20260901065947-dca4f84ef938` (no `replace` directive). Once the bridge releases a proper tag, `go.mod` should be updated to it.

## User Impact

Restores main branch to a buildable state; unblocks CI gates and Go tests. No runtime behavior change beyond what 3160a6f intended (AutoMemory limited to user turns in Room).

## Evidence

- `go build ./cmd/nexus-server ./cmd/nexusctl` ✅
- `go vet ./...` ✅
- `go test -count=1 ./internal/service/room/realtime/...` ✅ (18.4s)
- `make check-go-full` ✅ (full Go suite, exit 0)

Fixes nexus-research-lab/nexus#256