### PR TITLE
fix: #260 [Regression] nexus-server exits at startup when nexus-control is unreachable

### DIFF
--- a/internal/app/server/control_identity_invalidation_test.go
+++ b/internal/app/server/control_identity_invalidation_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,38 @@ type fakeControlInvalidationSource struct {
 	mu      sync.Mutex
 	applied []int64
 	done    chan struct{}
+}
+
+type fakeControlInvalidationStartupSource struct {
+	authsvc.Authority
+	latestErr error
+	seenAfter chan int64
+}
+
+func (f *fakeControlInvalidationStartupSource) LatestControlIdentityInvalidationID(context.Context) (int64, error) {
+	return 0, f.latestErr
+}
+
+func (f *fakeControlInvalidationStartupSource) ControlIdentityInvalidations(
+	_ context.Context,
+	after int64,
+) ([]authsvc.ControlIdentityInvalidation, error) {
+	select {
+	case f.seenAfter <- after:
+	default:
+	}
+	return nil, errors.New("control unavailable")
+}
+
+func (f *fakeControlInvalidationStartupSource) ApplyControlIdentityInvalidation(
+	context.Context,
+	authsvc.ControlIdentityInvalidation,
+) (string, error) {
+	return "", nil
+}
+
+func (f *fakeControlInvalidationStartupSource) FailClosedControlIdentities(context.Context) ([]string, error) {
+	return nil, nil
 }
 
 func (f *fakeControlInvalidationSource) LatestControlIdentityInvalidationID(context.Context) (int64, error) {
@@ -81,5 +114,34 @@ func TestControlIdentityInvalidationCoordinatorAppliesOrderedEvent(t *testing.T)
 	defer source.mu.Unlock()
 	if len(source.applied) != 1 || source.applied[0] != 1 {
 		t.Fatalf("applied events = %v, want [1]", source.applied)
+	}
+}
+
+func TestStartControlIdentityInvalidationsFallsBackWhenLatestCursorUnavailable(t *testing.T) {
+	source := &fakeControlInvalidationStartupSource{
+		latestErr: errors.New("control unavailable"),
+		seenAfter: make(chan int64, 1),
+	}
+	server := &Server{
+		api:      shared.NewAPI(logx.NewDiscardLogger()),
+		services: &AppServices{Auth: source},
+	}
+
+	stop, err := server.startControlIdentityInvalidations(context.Background())
+	if err != nil {
+		t.Fatalf("startControlIdentityInvalidations() error = %v, want nil", err)
+	}
+	if stop == nil {
+		t.Fatal("startControlIdentityInvalidations() stop = nil, want cleanup function")
+	}
+	defer stop()
+
+	select {
+	case after := <-source.seenAfter:
+		if after != 0 {
+			t.Fatalf("ControlIdentityInvalidations() after = %d, want fallback cursor 0", after)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Control identity invalidation coordinator 未在初始 cursor 失败后启动")
 	}
 }

--- a/internal/app/server/lifecycle.go
+++ b/internal/app/server/lifecycle.go
@@ -127,7 +127,10 @@ func (s *Server) startControlIdentityInvalidations(ctx context.Context) (func(),
 	}
 	cursor, err := source.LatestControlIdentityInvalidationID(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("initialize Control identity invalidation cursor: %w", err)
+		// 与运行时轮询保持一致：Control 暂时不可用时先从 cursor=0 启动，
+		// 由 runControlIdentityInvalidations 在 grace 窗口后执行既有 fail-closed 逻辑。
+		s.api.BaseLogger().Warn("初始化 Control identity invalidation cursor 失败，从 0 开始等待 Control 恢复", "err", err)
+		cursor = 0
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})


### PR DESCRIPTION
## What Problem This Solves

`nexus-server` currently exits during startup when the initial request for the latest Control identity invalidation cursor fails. This makes a temporary `nexus-control` startup ordering issue or brief unavailability fatal, even though the runtime polling path already tolerates Control outages and applies the existing fail-closed behavior after the grace window.

## Why This Change Was Made

This keeps startup behavior consistent with the runtime coordinator: log a warning, start from cursor `0`, and let `runControlIdentityInvalidations` retry/catch up while Control recovers. Sustained unavailability still goes through the existing `controlInvalidationGrace` fail-closed path.

## User Impact

Deployments no longer crash-loop when `nexus-control` is temporarily unreachable while `nexus-server` starts. Other server functionality can continue starting while the identity invalidation coordinator retries in the background.

## Evidence

- Added `TestStartControlIdentityInvalidationsFallsBackWhenLatestCursorUnavailable`.
- Passed: `go test ./internal/app/server -run 'Test(StartControlIdentityInvalidationsFallsBackWhenLatestCursorUnavailable|ControlIdentityInvalidationCoordinatorAppliesOrderedEvent)' -count=1`.
- Note: current `main` still has the unrelated bridge compile regression from #256, so the test was verified with the known temporary local bridge main pseudo-version workaround (`v0.1.32-0.20260901065947-dca4f84ef938`). That workaround is not included in this PR; #258 already tracks the dependency fix.

Fixes nexus-research-lab/nexus-core#260
